### PR TITLE
Added streaming of response body

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 from urllib.parse import urlparse, parse_qsl, urlencode
 
 import collections
-from aiohttp import hdrs, ClientResponse, ClientConnectionError, client
+from aiohttp import (
+    hdrs, ClientResponse, ClientConnectionError, StreamReader, client)
 from functools import wraps
 from multidict import CIMultiDict
 
@@ -55,7 +56,9 @@ class UrlResponse(object):
         if self.headers:
             self.resp.headers.update(self.headers)
         self.resp.status = self.status
-        self.resp._content = self.body
+        self.resp.content = StreamReader()
+        self.resp.content.feed_data(self.body)
+        self.resp.content.feed_eof()
 
         return self.resp
 

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -65,6 +65,22 @@ class AIOResponsesTestCase(TestCase):
         with self.assertRaises(ClientConnectionError):
             self.loop.run_until_complete(self.session.post(self.url))
 
+    @aioresponses()
+    def test_streaming(self, m):
+        m.get(self.url, body='Test')
+        resp = self.loop.run_until_complete(self.session.get(self.url))
+        content = self.loop.run_until_complete(resp.content.read())
+        self.assertEqual(content, b'Test')
+
+    @aioresponses()
+    def test_streaming_up_to(self, m):
+        m.get(self.url, body='Test')
+        resp = self.loop.run_until_complete(self.session.get(self.url))
+        content = self.loop.run_until_complete(resp.content.read(2))
+        self.assertEqual(content, b'Te')
+        content = self.loop.run_until_complete(resp.content.read(2))
+        self.assertEqual(content, b'st')
+
     def test_mocking_as_context_manager(self):
         with aioresponses() as aiomock:
             aiomock.add(self.url, payload={'foo': 'bar'})


### PR DESCRIPTION
For support of http://aiohttp.readthedocs.io/en/stable/client.html#streaming-response-content.