### PR TITLE
Allow use of yarl.URL objects

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -38,6 +38,7 @@ class UrlResponse(object):
 
     def parse_url(self, url: str) -> str:
         """Normalize url to make comparisons."""
+        url = str(url)
         _url = url.split('?')[0]
         query = urlencode(sorted(parse_qsl(urlparse(url).query)))
 


### PR DESCRIPTION
Using aiobotocore with aioresponses was throwing an exception because aioresponses was expecting a `str` url but aiobotocore provides a `yarl.URL` object.  This fixed the issue for me.