### PR TITLE
Add raw_headers to responses. Allow custom response classes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ ENV/
 .ropeproject
 
 *.idea/*
+.envrc
+.direnv

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -79,7 +79,7 @@ Ready to contribute? Here's how to set up `aioresponses` for local development.
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
     $ flake8 aioresponses tests
-    $ python setup.py test or py.test
+    $ python setup.py test
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.


### PR DESCRIPTION
`raw_headers` is set on "real" ClientResponse objects so this better mocks those. 

aiohttp allows one to set a custom response class.  To mock aiobotocore responses properly it was necessary to use a custom response class.