### PR TITLE
fix tests for aiohttp 1.0.x and do not run tests on "master" branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ matrix:
     - python: 3.4
       env: TOXENV=py34-aiohttp21
     - python: 3.4
-      env: TOXENV=py34-aiohttpmaster
+      env: TOXENV=py34-aiohttp22
+    - python: 3.4
+      env: TOXENV=py34-aiohttp23
 
     - python: 3.5
       env: TOXENV=py35-aiohttp10
@@ -31,7 +33,11 @@ matrix:
     - python: 3.5
       env: TOXENV=py35-aiohttp21
     - python: 3.5
-      env: TOXENV=py35-aiohttpmaster
+      env: TOXENV=py35-aiohttp22
+    - python: 3.5
+      env: TOXENV=py35-aiohttp23
+#    - python: 3.5
+#      env: TOXENV=py35-aiohttpmaster
 
     - python: 3.5
       env: TOXENV=flake8

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
+from aiohttp import __version__ as aiohttp_version
 from typing import Optional
 from urllib.parse import urlsplit, urlencode, SplitResult, urlunsplit
 
 try:
     from yarl import URL
-    __yarl_available = True
+    print(aiohttp_version)
+    if aiohttp_version.split('.')[:2] == ['1', '0']:
+        # yarl was introduced in version 1.1
+        raise ImportError
+    yarl_available = True
 except ImportError:
     class URL(str):
         pass
-    __yarl_available = False
+    yarl_available = False
 
 
 __all__ = ['URL', 'merge_url_params']
@@ -48,7 +53,7 @@ def _yarl_merge_url_params(url: str, params: Optional[dict]) -> str:
         return str(url.with_query(params))
 
 
-if __yarl_available:
+if yarl_available:
     merge_url_params = _yarl_merge_url_params
 else:
     merge_url_params = _vanilla_merge_url_params

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from ddt import ddt, data
 from aioresponses.compat import (
-    _vanilla_merge_url_params, _yarl_merge_url_params, URL
+    _vanilla_merge_url_params, _yarl_merge_url_params, yarl_available
 )
 
 
@@ -13,10 +13,9 @@ class CompatTestCase(TestCase):
     def setUp(self):
         self.url_with_parameters = 'http://example.com/api?foo=bar#fragment'
         self.url_without_parameters = 'http://example.com/api?#fragment'
-        self.yarn_available = not isinstance(URL, str)
 
     def _get_merge_functions(self):
-        if self.yarn_available:
+        if yarl_available:
             return {
                 _vanilla_merge_url_params,
                 _yarl_merge_url_params

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     flake8,
     coverage,
-    {py34,py35}-aiohttp{10,11,12,13,20,21,22,master}
+    py34-aiohttp{10,11,12,13,20,21,22,23}
+    py35-aiohttp{10,11,12,13,20,21,22,23}
 skipsdist=True
 
 [testenv:flake8]
@@ -23,6 +24,7 @@ deps =
     aiohttp20: aiohttp>=2.0,<2.1
     aiohttp21: aiohttp>=2.1,<2.2
     aiohttp22: aiohttp>=2.2,<2.3
+    aiohttp23: aiohttp>=2.3,<2.4
     aiohttpmaster: https://github.com/KeepSafe/aiohttp/archive/master.tar.gz
     -r{toxinidir}/requirements-dev.txt
 


### PR DESCRIPTION
py3.4 is not longer supported in aiohttp in future version 3.x.x(currently on branch master)

Signed-off-by: Pawel Nuckowski <p.nuckowski@gmail.com>