### PR TITLE
Don't print aiohttp version

### DIFF
--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -5,7 +5,6 @@ from urllib.parse import urlsplit, urlencode, SplitResult, urlunsplit
 
 try:
     from yarl import URL
-    print(aiohttp_version)
     if aiohttp_version.split('.')[:2] == ['1', '0']:
         # yarl was introduced in version 1.1
         raise ImportError


### PR DESCRIPTION
I'd suggest that we don't print the `aiohttp` version (or perhaps move it behind an env variable flag or something).  I feel that it is best practice to not pollute `stdout` when running tests.