### PR TITLE
aiohttp 3 adaptation

### DIFF
--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from aiohttp import __version__ as aiohttp_version
+from aiohttp import __version__ as aiohttp_version, StreamReader
 from typing import Optional
 from urllib.parse import urlsplit, urlencode, SplitResult, urlunsplit
 
@@ -13,6 +13,17 @@ except ImportError:
     class URL(str):
         pass
     yarl_available = False
+
+
+if int(aiohttp_version.split('.')[0]) >= 3:
+    from aiohttp.client_proto import ResponseHandler
+
+    def stream_reader():
+        protocol = ResponseHandler()
+        return StreamReader(protocol)
+else:
+    def stream_reader():
+        return StreamReader()
 
 
 __all__ = ['URL', 'merge_url_params']

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse, parse_qsl, urlencode
 from aiohttp import (
     hdrs, ClientResponse, ClientConnectionError, StreamReader, client
 )
+from aiohttp.client_proto import ResponseHandler
 from collections import namedtuple
 from functools import wraps
 from multidict import CIMultiDict
@@ -61,7 +62,8 @@ class UrlResponse(object):
             self.resp.headers.update(self.headers)
             self.resp.raw_headers = self._build_raw_headers(self.resp.headers)
         self.resp.status = self.status
-        self.resp.content = StreamReader()
+        protocol = ResponseHandler()
+        self.resp.content = StreamReader(protocol)
         self.resp.content.feed_data(self.body)
         self.resp.content.feed_eof()
 

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -6,15 +6,12 @@ from typing import Dict, Tuple
 from unittest.mock import patch
 from urllib.parse import urlparse, parse_qsl, urlencode
 
-from aiohttp import (
-    hdrs, ClientResponse, ClientConnectionError, StreamReader, client
-)
-from aiohttp.client_proto import ResponseHandler
+from aiohttp import ClientConnectionError, ClientResponse, client, hdrs
 from collections import namedtuple
 from functools import wraps
 from multidict import CIMultiDict
 
-from .compat import URL, merge_url_params
+from .compat import URL, merge_url_params, stream_reader
 
 
 class UrlResponse(object):
@@ -62,8 +59,7 @@ class UrlResponse(object):
             self.resp.headers.update(self.headers)
             self.resp.raw_headers = self._build_raw_headers(self.resp.headers)
         self.resp.status = self.status
-        protocol = ResponseHandler()
-        self.resp.content = StreamReader(protocol)
+        self.resp.content = stream_reader()
         self.resp.content.feed_data(self.body)
         self.resp.content.feed_eof()
 


### PR DESCRIPTION
`aiohttp` version `3.0.0` was released and there is the new `protocol` parameter at `StreamReader.__init__` so we need to fix `StreamReader` initializing.

There are also 2 issues to resolve withing this PR:
- [x] ImportError: No module named 'aiohttp.client_proto'
- [ ] Ubiquitous exception: `AttributeError: 'generator' object has no attribute '__await__'` (maybe because `aiohttp` version `3.0.0` requires Python 3.5.3+)