### PR TITLE
Upgrade to aiohttp v3 series and drop support for v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,29 +5,6 @@ language: python
 
 matrix:
   include:
-    - python: 3.4
-      env: TOXENV=py34-aiohttp10
-    - python: 3.4
-      env: TOXENV=py34-aiohttp12
-    - python: 3.4
-      env: TOXENV=py34-aiohttp13
-    - python: 3.4
-      env: TOXENV=py34-aiohttp20
-    - python: 3.4
-      env: TOXENV=py34-aiohttp21
-    - python: 3.4
-      env: TOXENV=py34-aiohttp22
-    - python: 3.4
-      env: TOXENV=py34-aiohttp23
-
-    - python: 3.5
-      env: TOXENV=py35-aiohttp10
-    - python: 3.5
-      env: TOXENV=py35-aiohttp11
-    - python: 3.5
-      env: TOXENV=py35-aiohttp12
-    - python: 3.5
-      env: TOXENV=py35-aiohttp13
     - python: 3.5
       env: TOXENV=py35-aiohttp20
     - python: 3.5
@@ -36,12 +13,26 @@ matrix:
       env: TOXENV=py35-aiohttp22
     - python: 3.5
       env: TOXENV=py35-aiohttp23
-#    - python: 3.5
-#      env: TOXENV=py35-aiohttpmaster
+    - python: 3.5
+      env: TOXENV=py35-aiohttp30
 
-    - python: 3.5
+    - python: 3.6
+      env: TOXENV=py36-aiohttp20
+    - python: 3.6
+      env: TOXENV=py36-aiohttp21
+    - python: 3.6
+      env: TOXENV=py36-aiohttp22
+    - python: 3.6
+      env: TOXENV=py36-aiohttp23
+    - python: 3.6
+      env: TOXENV=py36-aiohttp30
+#    - python: 3.6
+#      env: TOXENV=py36-aiohttpmaster
+#
+
+    - python: 3.6
       env: TOXENV=flake8
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=coverage
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from aiohttp import __version__ as aiohttp_version
+from aiohttp import __version__ as aiohttp_version, StreamReader
 from typing import Optional
 from urllib.parse import urlsplit, urlencode, SplitResult, urlunsplit
 
@@ -13,6 +13,17 @@ except ImportError:
     class URL(str):
         pass
     yarl_available = False
+
+
+if int(aiohttp_version.split('.')[0]) >= 3:
+    from aiohttp.client_proto import ResponseHandler
+
+    def stream_reader():
+        protocol = ResponseHandler()
+        return StreamReader(protocol)
+else:
+    def stream_reader():
+        return StreamReader()
 
 
 __all__ = ['URL', 'merge_url_params']

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -189,8 +189,8 @@ class aioresponses(object):
         return resp
 
     async def _request_mock(self, orig_self: client.ClientSession,
-                      method: str, url: str, *args: Tuple,
-                      **kwargs: Dict) -> 'ClientResponse':
+                            method: str, url: str, *args: Tuple,
+                            **kwargs: Dict) -> 'ClientResponse':
         """Return mocked response object or raise connection error."""
 
         url = merge_url_params(url, kwargs.get('params'))

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 from typing import Dict, Tuple
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from urllib.parse import urlparse, parse_qsl, urlencode
 
 from aiohttp import (
@@ -61,7 +61,7 @@ class UrlResponse(object):
             self.resp.headers.update(self.headers)
             self.resp.raw_headers = self._build_raw_headers(self.resp.headers)
         self.resp.status = self.status
-        self.resp.content = StreamReader()
+        self.resp.content = StreamReader(Mock(_reading_paused=False))
         self.resp.content.feed_data(self.body)
         self.resp.content.feed_eof()
 
@@ -188,8 +188,7 @@ class aioresponses(object):
             del self._responses[i]
         return resp
 
-    @asyncio.coroutine
-    def _request_mock(self, orig_self: client.ClientSession,
+    async def _request_mock(self, orig_self: client.ClientSession,
                       method: str, url: str, *args: Tuple,
                       **kwargs: Dict) -> 'ClientResponse':
         """Return mocked response object or raise connection error."""
@@ -198,7 +197,7 @@ class aioresponses(object):
 
         for prefix in self._passthrough:
             if str(url).startswith(prefix):
-                return (yield from self.patcher.temp_original(
+                return (await self.patcher.temp_original(
                     orig_self, method, url, *args, **kwargs
                 ))
 

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -3,17 +3,17 @@
 import asyncio
 import json
 from typing import Dict, Tuple
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from urllib.parse import urlparse, parse_qsl, urlencode
 
 from aiohttp import (
-    hdrs, ClientResponse, ClientConnectionError, StreamReader, client
+    hdrs, ClientResponse, ClientConnectionError, client
 )
 from collections import namedtuple
 from functools import wraps
 from multidict import CIMultiDict
 
-from .compat import URL, merge_url_params
+from .compat import URL, merge_url_params, stream_reader
 
 
 class UrlResponse(object):
@@ -61,7 +61,7 @@ class UrlResponse(object):
             self.resp.headers.update(self.headers)
             self.resp.raw_headers = self._build_raw_headers(self.resp.headers)
         self.resp.status = self.status
-        self.resp.content = StreamReader(Mock(_reading_paused=False))
+        self.resp.content = stream_reader()
         self.resp.content.feed_data(self.body)
         self.resp.content.feed_eof()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,8 @@ classifier =
   License :: OSI Approved :: MIT License
   Natural Language :: English
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.4
   Programming Language :: Python :: 3.5
+  Programming Language :: Python :: 3.6
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8,
     coverage,
-    py34-aiohttp{10,11,12,13,20,21,22,23}
-    py35-aiohttp{10,11,12,13,20,21,22,23}
+    py35-aiohttp{20,21,22,23,30}
+    py36-aiohttp{20,21,22,23,30}
 skipsdist=True
 
 [testenv:flake8]
@@ -17,20 +17,17 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/aioresponses
 
 deps =
-    aiohttp10: aiohttp>=1.0,<1.1
-    aiohttp11: aiohttp>=1.1,<1.2
-    aiohttp12: aiohttp>=1.2,<1.3
-    aiohttp13: aiohttp>=1.3,<2.0
     aiohttp20: aiohttp>=2.0,<2.1
     aiohttp21: aiohttp>=2.1,<2.2
     aiohttp22: aiohttp>=2.2,<2.3
     aiohttp23: aiohttp>=2.3,<2.4
+    aiohttp30: aiohttp>=3.0,<3.1
     aiohttpmaster: https://github.com/KeepSafe/aiohttp/archive/master.tar.gz
     -r{toxinidir}/requirements-dev.txt
 
 basepython =
-    py34: python3.4
     py35: python3.5
+    py36: python3.6
 
 commands = python setup.py test
 


### PR DESCRIPTION
* This PR is for #88.

* aiohttp v3 uses native async/await syntax and drops support for
  Python 3.5.2 or lower.

* I think it would be reasonable enough to support latest two major
  versions of aiohttp: v2 and v3 series.
  (Of course the decision is up to the main author of this project!)