### PR TITLE
Improvement/drop old code small redesign

### DIFF
--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -33,9 +33,9 @@ else:  # pragma: no cover
 def merge_params(url: 'Union[URL, str]', params: 'Dict' = None) -> 'URL':
     url = URL(url)
     if params:
-        multi_params = MultiDict(url.query)
-        multi_params.extend(url.with_query(params).query)
-        url = url.with_query(multi_params)
+        query_params = MultiDict(url.query)
+        query_params.extend(url.with_query(params).query)
+        return url.with_query(query_params)
     return url
 
 

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -10,7 +10,7 @@ from yarl import URL
 
 try:
     Pattern = re._pattern_type
-except AttributeError:
+except AttributeError:  # pragma: no cover
     # Python 3.7
     Pattern = re.Pattern
 
@@ -19,13 +19,12 @@ VERSION = StrictVersion(__aioversion__)
 if VERSION >= StrictVersion('3.0.0'):
     from aiohttp.client_proto import ResponseHandler
 
-
     def stream_reader_factory():
         protocol = ResponseHandler()
         return StreamReader(protocol)
 
 
-else:
+else:  # pragma: no cover
 
     def stream_reader_factory():
         return StreamReader()

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 import re
 from typing import Optional, Union, Dict
-from urllib.parse import urlsplit, urlencode, SplitResult, urlunsplit, \
-    parse_qsl
+from urllib.parse import (
+    urlsplit,
+    urlencode,
+    SplitResult,
+    urlunsplit,
+    parse_qsl,
+)
 
 from aiohttp import __version__ as aiohttp_version, StreamReader
 from multidict.__init__ import MultiDict
@@ -15,17 +20,6 @@ except AttributeError:
 yarl_available = False
 from yarl import URL
 
-# try:
-#
-#
-#     if aiohttp_version.split('.')[:2] == ['1', '0']:
-#         # yarl was introduced in version 1.1
-#         raise ImportError
-#     yarl_available = True
-# except ImportError:
-#     class URL(str):
-#         pass
-
 if int(aiohttp_version.split('.')[0]) >= 3:
     from aiohttp.client_proto import ResponseHandler
 
@@ -33,49 +27,12 @@ if int(aiohttp_version.split('.')[0]) >= 3:
     def stream_reader_factory():
         protocol = ResponseHandler()
         return StreamReader(protocol)
+
+
 else:
+
     def stream_reader_factory():
         return StreamReader()
-
-
-def _vanilla_merge_url_params(url: str, params: Optional[dict]) -> str:
-    if not params:
-        return url
-    url_split = urlsplit(url)
-
-    if url_split.query:
-        qs = "{}&{}".format(url_split.query, urlencode(params))
-    else:
-        qs = urlencode(params)
-
-    new = SplitResult(
-        scheme=url_split.scheme,
-        netloc=url_split.netloc,
-        path=url_split.path,
-        query=qs,
-        fragment=url_split.fragment
-    )
-
-    return urlunsplit(new)
-
-
-def _yarl_merge_url_params(url: str, params: Optional[dict]) -> str:
-    if not params:
-        return url
-
-    url = URL(url)
-    if url.query_string:
-        return str(url.with_query(
-            "{}&{}".format(url.query_string, urlencode(params)))
-        )
-    else:
-        return str(url.with_query(params))
-
-
-if yarl_available:
-    merge_url_params = _yarl_merge_url_params
-else:
-    merge_url_params = _vanilla_merge_url_params
 
 
 def merge_params(url: Union[URL, str], params: Dict = None) -> 'URL':
@@ -93,9 +50,4 @@ def normalize_url(url: Union[URL, str]) -> 'URL':
     return url.with_query(urlencode(sorted(parse_qsl(url.query_string))))
 
 
-__all__ = [
-    'URL',
-    'Pattern',
-    'merge_url_params',
-    'stream_reader_factory',
-]
+__all__ = ['URL', 'Pattern', 'merge_params', 'stream_reader_factory']

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -4,7 +4,7 @@ from distutils.version import StrictVersion
 from typing import Union, Dict  # noqa
 from urllib.parse import urlencode, parse_qsl
 
-from aiohttp import __version__ as __aioversion__, StreamReader
+from aiohttp import __version__ as aiohttp_version, StreamReader
 from multidict import MultiDict
 from yarl import URL
 
@@ -14,9 +14,9 @@ except AttributeError:  # pragma: no cover
     # Python 3.7
     Pattern = re.Pattern
 
-VERSION = StrictVersion(__aioversion__)
+AIOHTTP_VERSION = StrictVersion(aiohttp_version)
 
-if VERSION >= StrictVersion('3.0.0'):
+if AIOHTTP_VERSION >= StrictVersion('3.0.0'):
     from aiohttp.client_proto import ResponseHandler
 
     def stream_reader_factory():
@@ -48,7 +48,7 @@ def normalize_url(url: 'Union[URL, str]') -> 'URL':
 __all__ = [
     'URL',
     'Pattern',
-    'VERSION',
+    'AIOHTTP_VERSION',
     'merge_params',
     'stream_reader_factory',
     'normalize_url',

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,26 +1,22 @@
 # -*- coding: utf-8 -*-
 import re
-from typing import Optional, Union, Dict
-from urllib.parse import (
-    urlsplit,
-    urlencode,
-    SplitResult,
-    urlunsplit,
-    parse_qsl,
-)
+from distutils.version import StrictVersion
+from typing import Union, Dict  # noqa
+from urllib.parse import urlencode, parse_qsl
 
-from aiohttp import __version__ as aiohttp_version, StreamReader
-from multidict.__init__ import MultiDict
+from aiohttp import __version__ as __aioversion__, StreamReader
+from multidict import MultiDict
+from yarl import URL
 
 try:
     Pattern = re._pattern_type
 except AttributeError:
     # Python 3.7
     Pattern = re.Pattern
-yarl_available = False
-from yarl import URL
 
-if int(aiohttp_version.split('.')[0]) >= 3:
+VERSION = StrictVersion(__aioversion__)
+
+if VERSION >= StrictVersion('3.0.0'):
     from aiohttp.client_proto import ResponseHandler
 
 
@@ -35,7 +31,7 @@ else:
         return StreamReader()
 
 
-def merge_params(url: Union[URL, str], params: Dict = None) -> 'URL':
+def merge_params(url: 'Union[URL, str]', params: 'Dict' = None) -> 'URL':
     url = URL(url)
     if params:
         multi_params = MultiDict(url.query)
@@ -44,10 +40,17 @@ def merge_params(url: Union[URL, str], params: Dict = None) -> 'URL':
     return url
 
 
-def normalize_url(url: Union[URL, str]) -> 'URL':
+def normalize_url(url: 'Union[URL, str]') -> 'URL':
     """Normalize url to make comparisons."""
     url = URL(url)
     return url.with_query(urlencode(sorted(parse_qsl(url.query_string))))
 
 
-__all__ = ['URL', 'Pattern', 'merge_params', 'stream_reader_factory']
+__all__ = [
+    'URL',
+    'Pattern',
+    'VERSION',
+    'merge_params',
+    'stream_reader_factory',
+    'normalize_url',
+]

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -4,29 +4,31 @@ import json
 from collections import namedtuple
 from distutils.version import StrictVersion
 from functools import wraps
-from typing import Dict, Tuple, Union, Optional
+from typing import Dict, Tuple, Union, Optional, List  # noqa
 from unittest.mock import Mock, patch
-from urllib.parse import parse_qsl, urlencode
 
-import aiohttp
 from aiohttp import ClientConnectionError, ClientResponse, client, hdrs
 from aiohttp.helpers import TimerNoop
 from multidict import CIMultiDict
-from typing import List
 
-from aioresponses.compat import merge_params, normalize_url
-from .compat import URL, stream_reader_factory, Pattern
-
-VERSION = StrictVersion(aiohttp.__version__)
-UrlType = Union[URL, str]
+from .compat import (
+    URL,
+    stream_reader_factory,
+    Pattern,
+    merge_params,
+    normalize_url,
+    VERSION
+)
 
 
 class MockedResponse(object):
     resp = None
     url_or_pattern = None  # type: Union[URL, Pattern]
 
-    def __init__(self, url: Union[str, Pattern], method: str = hdrs.METH_GET,
-                 status: int = 200, body: str = '',
+    def __init__(self, url: Union[str, Pattern],
+                 method: str = hdrs.METH_GET,
+                 status: int = 200,
+                 body: str = '',
                  exception: 'Exception' = None,
                  headers: Dict = None, payload: Dict = None,
                  content_type: str = 'application/json',
@@ -105,7 +107,7 @@ class MockedResponse(object):
         self.resp.content.feed_eof()
         return self.resp
 
-    def _build_raw_headers(self, headers):
+    def _build_raw_headers(self, headers: Dict) -> Tuple:
         """
         Convert a dict of headers to a tuple of tuples
 
@@ -171,28 +173,29 @@ class aioresponses(object):
         self.patcher.stop()
         self._responses = []
 
-    def head(self, url: str, **kwargs):
+    def head(self, url: 'Union[URL, str]', **kwargs):
         self.add(url, method=hdrs.METH_HEAD, **kwargs)
 
-    def get(self, url: str, **kwargs):
+    def get(self, url: 'Union[URL, str]', **kwargs):
         self.add(url, method=hdrs.METH_GET, **kwargs)
 
-    def post(self, url: str, **kwargs):
+    def post(self, url: 'Union[URL, str]', **kwargs):
         self.add(url, method=hdrs.METH_POST, **kwargs)
 
-    def put(self, url: str, **kwargs):
+    def put(self, url: 'Union[URL, str]', **kwargs):
         self.add(url, method=hdrs.METH_PUT, **kwargs)
 
-    def patch(self, url: str, **kwargs):
+    def patch(self, url: 'Union[URL, str]', **kwargs):
         self.add(url, method=hdrs.METH_PATCH, **kwargs)
 
-    def delete(self, url: str, **kwargs):
+    def delete(self, url: 'Union[URL, str]', **kwargs):
         self.add(url, method=hdrs.METH_DELETE, **kwargs)
 
-    def options(self, url: str, **kwargs):
+    def options(self, url: 'Union[URL, str]', **kwargs):
         self.add(url, method=hdrs.METH_OPTIONS, **kwargs)
 
-    def add(self, url: str, method: str = hdrs.METH_GET, status: int = 200,
+    def add(self, url: 'Union[URL, str]', method: str = hdrs.METH_GET,
+            status: int = 200,
             body: str = '',
             exception: 'Exception' = None,
             content_type: str = 'application/json',
@@ -230,7 +233,7 @@ class aioresponses(object):
         return resp
 
     async def _request_mock(self, orig_self: client.ClientSession,
-                            method: str, url: 'UrlType',
+                            method: str, url: 'Union[URL, str]',
                             *args: Tuple,
                             **kwargs: Dict) -> 'ClientResponse':
         """Return mocked response object or raise connection error."""

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -7,14 +7,14 @@ from functools import wraps
 from typing import Dict, Tuple, Union, Optional, List  # noqa
 from unittest.mock import Mock, patch
 
-from aiohttp import ClientConnectionError, ClientResponse, client, hdrs
+from aiohttp import ClientConnectionError, ClientResponse, ClientSession, hdrs
 from aiohttp.helpers import TimerNoop
 from multidict import CIMultiDict
 
 from .compat import (
     URL,
-    stream_reader_factory,
     Pattern,
+    stream_reader_factory,
     merge_params,
     normalize_url,
     VERSION
@@ -29,8 +29,9 @@ class MockedResponse(object):
                  method: str = hdrs.METH_GET,
                  status: int = 200,
                  body: str = '',
+                 payload: Dict = None,
                  exception: 'Exception' = None,
-                 headers: Dict = None, payload: Dict = None,
+                 headers: Dict = None,
                  content_type: str = 'application/json',
                  response_class: 'ClientResponse' = None,
                  timeout: bool = False,
@@ -232,7 +233,7 @@ class aioresponses(object):
             raise resp
         return resp
 
-    async def _request_mock(self, orig_self: client.ClientSession,
+    async def _request_mock(self, orig_self: ClientSession,
                             method: str, url: 'Union[URL, str]',
                             *args: Tuple,
                             **kwargs: Dict) -> 'ClientResponse':

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -17,7 +17,7 @@ from .compat import (
     stream_reader_factory,
     merge_params,
     normalize_url,
-    VERSION
+    AIOHTTP_VERSION
 )
 
 
@@ -74,7 +74,7 @@ class MockedResponse(object):
         if isinstance(self.exception, Exception):
             return self.exception
         kwargs = {}
-        if VERSION >= StrictVersion('3.1.0'):
+        if AIOHTTP_VERSION >= StrictVersion('3.1.0'):
             loop = Mock()
             loop.get_debug = Mock()
             loop.get_debug.return_value = True
@@ -82,7 +82,7 @@ class MockedResponse(object):
             kwargs['writer'] = Mock()
             kwargs['continue100'] = None
             kwargs['timer'] = TimerNoop()
-            if VERSION >= StrictVersion('3.3.0'):
+            if AIOHTTP_VERSION >= StrictVersion('3.3.0'):
                 pass
             else:
                 kwargs['auto_decompress'] = True
@@ -95,7 +95,7 @@ class MockedResponse(object):
         if self.headers:
             headers.update(self.headers)
         raw_headers = self._build_raw_headers(headers)
-        if VERSION >= StrictVersion('3.3.0'):
+        if AIOHTTP_VERSION >= StrictVersion('3.3.0'):
             # Reified attributes
             self.resp._headers = headers
             self.resp._raw_headers = raw_headers

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -215,7 +215,7 @@ class AIOResponsesTestCase(TestCase):
             resp = yield from self.session.get(self.url)
             self.assertEqual(resp.status, 202)
 
-            key = ('GET', self.url)
+            key = ('GET', URL(self.url))
             self.assertIn(key, m.requests)
             self.assertEqual(len(m.requests[key]), 3)
             self.assertEqual(m.requests[key][0].args, tuple())

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import asyncio
 import re
+from typing import Coroutine, Generator, Union
 from unittest.mock import patch
 
 from aiohttp import hdrs
@@ -8,17 +9,15 @@ from aiohttp.client import ClientSession
 from aiohttp.client_reqrep import ClientResponse
 from asynctest import fail_on
 from asynctest.case import TestCase
-from typing import Coroutine, Generator, Union
-
-from aioresponses.compat import URL
+from ddt import ddt, data
 
 try:
     from aiohttp.errors import ClientConnectionError, HttpProcessingError
 except ImportError:
     from aiohttp.client_exceptions import ClientConnectionError
     from aiohttp.http_exceptions import HttpProcessingError
-from ddt import ddt, data
 
+from aioresponses.compat import URL
 from aioresponses import aioresponses
 
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+from typing import Union
 from unittest import TestCase
 
 from ddt import ddt, data
-from typing import Union
 from yarl import URL
 
 from aioresponses.compat import merge_params

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,9 +1,15 @@
+# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 from ddt import ddt, data
-from aioresponses.compat import (
-    _vanilla_merge_url_params, _yarl_merge_url_params, yarl_available
-)
+from typing import Union
+from yarl import URL
+
+from aioresponses.compat import merge_params
+
+
+def get_url(url: str, as_str: bool) -> Union[URL, str]:
+    return url if as_str else URL(url)
 
 
 @ddt
@@ -14,58 +20,29 @@ class CompatTestCase(TestCase):
         self.url_with_parameters = 'http://example.com/api?foo=bar#fragment'
         self.url_without_parameters = 'http://example.com/api?#fragment'
 
-    def _get_merge_functions(self):
-        if yarl_available:
-            return {
-                _vanilla_merge_url_params,
-                _yarl_merge_url_params
-            }
-        return {
-            _vanilla_merge_url_params,
-        }
+    @data(True, False)
+    def test_no_params_returns_same_url__as_str(self, as_str):
+        url = get_url(self.url_with_parameters, as_str)
+        self.assertEqual(
+            merge_params(url, None), URL(self.url_with_parameters)
+        )
 
-    @data(
-        _vanilla_merge_url_params,
-        _yarl_merge_url_params
-    )
-    def test_no_params_returns_same_url(self, func):
-        if func in self._get_merge_functions():
-            self.assertEqual(
-                func(self.url_with_parameters, None),
-                self.url_with_parameters
-            )
+    @data(True, False)
+    def test_empty_params_returns_same_url__as_str(self, as_str):
+        url = get_url(self.url_with_parameters, as_str)
+        self.assertEqual(merge_params(url, {}), URL(self.url_with_parameters))
 
-    @data(
-        _vanilla_merge_url_params,
-        _yarl_merge_url_params
-    )
-    def test_empty_params_returns_same_url(self, func):
-        if func in self._get_merge_functions():
-            self.assertEqual(
-                func(self.url_with_parameters, {}),
-                self.url_with_parameters
-            )
+    @data(True, False)
+    def test_both_with_params_returns_corrected_url__as_str(self, as_str):
+        url = get_url(self.url_with_parameters, as_str)
+        self.assertEqual(
+            merge_params(url, {'x': 42}),
+            URL('http://example.com/api?foo=bar&x=42#fragment'),
+        )
 
-    @data(
-        _vanilla_merge_url_params,
-        _yarl_merge_url_params
-    )
-    def test_both_with_params_returns_corrected_url(self, func):
-        if func in self._get_merge_functions():
-            expected_url = 'http://example.com/api?foo=bar&x=42#fragment'
-            self.assertEqual(
-                func(self.url_with_parameters, {'x': 42}),
-                expected_url
-            )
+    @data(True, False)
+    def test_base_without_params_returns_corrected_url__as_str(self, as_str):
+        expected_url = URL('http://example.com/api?x=42#fragment')
+        url = get_url(self.url_without_parameters, as_str)
 
-    @data(
-        _vanilla_merge_url_params,
-        _yarl_merge_url_params
-    )
-    def test_base_without_params_returns_corrected_url(self, func):
-        if func in self._get_merge_functions():
-            expected_url = 'http://example.com/api?x=42#fragment'
-            self.assertEqual(
-                func(self.url_without_parameters, {'x': 42}),
-                expected_url
-            )
+        self.assertEqual(merge_params(url, {'x': 42}), expected_url)

--- a/tox.ini
+++ b/tox.ini
@@ -45,4 +45,4 @@ commands = coverage run --source=aioresponses setup.py test
 [testenv:cov_html]
 basepython = python
 deps = aiohttp
-commands = pytest --cov-report=html --cov-report=xml
+commands = pytest --cov=aioresponses/ --cov-report=html --cov-report=xml


### PR DESCRIPTION
fixes #79 
 - [x] Removed dead code from `compat`. Code is now simplified. We support `aiohttp` from version 2.x and that version of aiohttp  uses `yarl`. 
 - [x] aioresponses now accepts `yarl.URL`  and uses that as basic url type.