### PR TITLE
Provide default Reason Phrase from aiohttp.http.RESPONSES

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -7,7 +7,13 @@ from functools import wraps
 from typing import Dict, Tuple, Union, Optional, List  # noqa
 from unittest.mock import Mock, patch
 
-from aiohttp import ClientConnectionError, ClientResponse, ClientSession, hdrs, http
+from aiohttp import (
+    ClientConnectionError,
+    ClientResponse,
+    ClientSession,
+    hdrs,
+    http
+)
 from aiohttp.helpers import TimerNoop
 from multidict import CIMultiDict
 

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -66,7 +66,7 @@ class RequestMatch(object):
         if self.reason is None:
             try:
                 self.reason = http.RESPONSES[self.status][0]
-            except Exception:
+            except (IndexError, KeyError):
                 self.reason = ''
 
     def match_str(self, url: URL) -> bool:


### PR DESCRIPTION
Hi! Thanks for taking a look at my pull request.

## Summary

Fixes https://github.com/pnuckowski/aioresponses/issues/114:
- allows a `reason` to be specified when creating a mock aiohttp response
- by default, sets the `reason` to `aiohttp.http.RESPONSES[status][0]`, [which is what `aiohttp` does as a default](https://github.com/aio-libs/aiohttp/blob/0715ae79f9cbbc9cec6211be35df81d023b723c8/aiohttp/web_response.py#L120-L124)

## Motivation

https://github.com/pnuckowski/aioresponses/issues/114 is a bug I ran into as well the other day, and I wanted to provide a fix for it.