### PR TITLE
Add callbacks to provide dynamic responses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,28 @@ for convenience use *payload* argument to mock out json response. Example below.
         # will throw an exception.
 
 
+**aioresponses allows to use callbacks to provide dynamic responses**
+
+.. code:: python
+
+    import asyncio
+    import aiohttp
+    from aioresponses import aioresponses
+
+    async def callback(match, url, *args, **kwargs):
+        return match.build_response(url, status=418)
+
+    @aioresponses()
+    def test_callback(m, test_client):
+        loop = asyncio.get_event_loop()
+        session = ClientSession()
+        m.get('http://example.com', callback=callback)
+
+        resp = loop.run_until_complete(session.get('http://example.com'))
+
+        assert resp.status == 418
+
+
 **aioresponses can be used in a pytest fixture**
 
 .. code:: python
@@ -201,8 +223,6 @@ for convenience use *payload* argument to mock out json response. Example below.
     def mock_aioresponse():
         with aioresponses() as m:
             yield m
-
-
 
 
 Features

--- a/README.rst
+++ b/README.rst
@@ -196,10 +196,10 @@ for convenience use *payload* argument to mock out json response. Example below.
 
     import asyncio
     import aiohttp
-    from aioresponses import aioresponses, build_response
+    from aioresponses import CallbackResult, aioresponses
 
     def callback(url, **kwargs):
-        return build_response(url, status=418)
+        return CallbackResult(url, status=418)
 
     @aioresponses()
     def test_callback(m, test_client):

--- a/README.rst
+++ b/README.rst
@@ -199,7 +199,7 @@ for convenience use *payload* argument to mock out json response. Example below.
     from aioresponses import CallbackResult, aioresponses
 
     def callback(url, **kwargs):
-        return CallbackResult(url, status=418)
+        return CallbackResult(status=418)
 
     @aioresponses()
     def test_callback(m, test_client):

--- a/README.rst
+++ b/README.rst
@@ -196,10 +196,10 @@ for convenience use *payload* argument to mock out json response. Example below.
 
     import asyncio
     import aiohttp
-    from aioresponses import aioresponses
+    from aioresponses import aioresponses, build_response
 
-    async def callback(match, url, *args, **kwargs):
-        return match.build_response(url, status=418)
+    def callback(url, **kwargs):
+        return build_response(url, status=418)
 
     @aioresponses()
     def test_callback(m, test_client):

--- a/aioresponses/__init__.py
+++ b/aioresponses/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from .compat import build_response
 from .core import aioresponses
 
 __version__ = '0.4.1'

--- a/aioresponses/__init__.py
+++ b/aioresponses/__init__.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-from .compat import build_response
+from .compat import CallbackResult
 from .core import aioresponses
 
 __version__ = '0.4.1'
 
 __all__ = [
     'aioresponses',
+    'CallbackResult',
 ]

--- a/aioresponses/__init__.py
+++ b/aioresponses/__init__.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-from .compat import CallbackResult
-from .core import aioresponses
+from .core import CallbackResult, aioresponses
 
 __version__ = '0.4.1'
 
 __all__ = [
-    'aioresponses',
     'CallbackResult',
+    'aioresponses',
 ]

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,20 +1,12 @@
 # -*- coding: utf-8 -*-
 import asyncio  # noqa
-import json
 import re
 from distutils.version import StrictVersion
 from typing import Dict, Optional, Tuple, Union  # noqa
-from unittest.mock import Mock
 from urllib.parse import parse_qsl, urlencode
 
-from aiohttp import (
-    __version__ as aiohttp_version,
-    ClientResponse,
-    StreamReader,
-    hdrs,
-)
-from aiohttp.helpers import TimerNoop
-from multidict import CIMultiDict, MultiDict
+from aiohttp import __version__ as aiohttp_version, StreamReader
+from multidict import MultiDict
 from yarl import URL
 
 try:
@@ -55,90 +47,6 @@ def normalize_url(url: 'Union[URL, str]') -> 'URL':
     return url.with_query(urlencode(sorted(parse_qsl(url.query_string))))
 
 
-def _build_raw_headers(headers: Dict) -> Tuple:
-    """
-    Convert a dict of headers to a tuple of tuples
-
-    Mimics the format of ClientResponse.
-    """
-    raw_headers = []
-    for k, v in headers.items():
-        raw_headers.append((k.encode('utf8'), v.encode('utf8')))
-    return tuple(raw_headers)
-
-
-def build_response(
-        url: 'Union[URL, str]',
-        method: str = hdrs.METH_GET,
-        status: int = 200,
-        body: str = '',
-        content_type: str = 'application/json',
-        payload: Dict = None,
-        headers: Dict = None,
-        response_class: 'ClientResponse' = None,
-        reason: Optional[str] = None) -> ClientResponse:
-    if response_class is None:
-        response_class = ClientResponse
-    if payload is not None:
-        body = json.dumps(payload)
-    if not isinstance(body, bytes):
-        body = str.encode(body)
-    kwargs = {}
-    if AIOHTTP_VERSION >= StrictVersion('3.1.0'):
-        loop = Mock()
-        loop.get_debug = Mock()
-        loop.get_debug.return_value = True
-        kwargs['request_info'] = Mock()
-        kwargs['writer'] = Mock()
-        kwargs['continue100'] = None
-        kwargs['timer'] = TimerNoop()
-        if AIOHTTP_VERSION < StrictVersion('3.3.0'):
-            kwargs['auto_decompress'] = True
-        kwargs['traces'] = []
-        kwargs['loop'] = loop
-        kwargs['session'] = None
-    _headers = CIMultiDict({hdrs.CONTENT_TYPE: content_type})
-    if headers:
-        _headers.update(headers)
-    raw_headers = _build_raw_headers(_headers)
-    resp = response_class(method, url, **kwargs)
-    if AIOHTTP_VERSION >= StrictVersion('3.3.0'):
-        # Reified attributes
-        resp._headers = _headers
-        resp._raw_headers = raw_headers
-    else:
-        resp.headers = _headers
-        resp.raw_headers = raw_headers
-    resp.status = status
-    resp.reason = reason
-    resp.content = stream_reader_factory()
-    resp.content.feed_data(body)
-    resp.content.feed_eof()
-    return resp
-
-
-class CallbackResult:
-
-    def __init__(self, url: 'Union[URL, str]',
-                 method: str = hdrs.METH_GET,
-                 status: int = 200,
-                 body: str = '',
-                 content_type: str = 'application/json',
-                 payload: Dict = None,
-                 headers: Dict = None,
-                 response_class: 'ClientResponse' = None,
-                 reason: Optional[str] = None):
-        self.url = url
-        self.method = method
-        self.status = status
-        self.body = body
-        self.content_type = content_type
-        self.payload = payload
-        self.headers = headers
-        self.response_class = response_class
-        self.reason = reason
-
-
 __all__ = [
     'URL',
     'Pattern',
@@ -146,6 +54,4 @@ __all__ = [
     'merge_params',
     'stream_reader_factory',
     'normalize_url',
-    'build_response',
-    'CallbackResult',
 ]

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -117,6 +117,28 @@ def build_response(
     return resp
 
 
+class CallbackResult:
+
+    def __init__(self, url: 'Union[URL, str]',
+                 method: str = hdrs.METH_GET,
+                 status: int = 200,
+                 body: str = '',
+                 content_type: str = 'application/json',
+                 payload: Dict = None,
+                 headers: Dict = None,
+                 response_class: 'ClientResponse' = None,
+                 reason: Optional[str] = None):
+        self.url = url
+        self.method = method
+        self.status = status
+        self.body = body
+        self.content_type = content_type
+        self.payload = payload
+        self.headers = headers
+        self.response_class = response_class
+        self.reason = reason
+
+
 __all__ = [
     'URL',
     'Pattern',
@@ -125,4 +147,5 @@ __all__ = [
     'stream_reader_factory',
     'normalize_url',
     'build_response',
+    'CallbackResult',
 ]

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import asyncio
+import asyncio  # noqa
 import re
 from distutils.version import StrictVersion
 from typing import Dict, Optional, Union  # noqa

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,13 +1,20 @@
 # -*- coding: utf-8 -*-
 import asyncio  # noqa
+import json
 import re
 from distutils.version import StrictVersion
-from typing import Dict, Optional, Union  # noqa
+from typing import Dict, Optional, Tuple, Union  # noqa
+from unittest.mock import Mock
 from urllib.parse import parse_qsl, urlencode
 
-from aiohttp import StreamReader
-from aiohttp import __version__ as aiohttp_version
-from multidict import MultiDict
+from aiohttp import (
+    __version__ as aiohttp_version,
+    ClientResponse,
+    StreamReader,
+    hdrs,
+)
+from aiohttp.helpers import TimerNoop
+from multidict import CIMultiDict, MultiDict
 from yarl import URL
 
 try:
@@ -26,7 +33,6 @@ if AIOHTTP_VERSION >= StrictVersion('3.0.0'):
     ):
         protocol = ResponseHandler(loop=loop)
         return StreamReader(protocol)
-
 
 else:  # pragma: no cover
 
@@ -49,6 +55,68 @@ def normalize_url(url: 'Union[URL, str]') -> 'URL':
     return url.with_query(urlencode(sorted(parse_qsl(url.query_string))))
 
 
+def _build_raw_headers(headers: Dict) -> Tuple:
+    """
+    Convert a dict of headers to a tuple of tuples
+
+    Mimics the format of ClientResponse.
+    """
+    raw_headers = []
+    for k, v in headers.items():
+        raw_headers.append((k.encode('utf8'), v.encode('utf8')))
+    return tuple(raw_headers)
+
+
+def build_response(
+        url: 'Union[URL, str]',
+        method: str = hdrs.METH_GET,
+        status: int = 200,
+        body: str = '',
+        content_type: str = 'application/json',
+        payload: Dict = None,
+        headers: Dict = None,
+        response_class: 'ClientResponse' = None,
+        reason: Optional[str] = None) -> ClientResponse:
+    if response_class is None:
+        response_class = ClientResponse
+    if payload is not None:
+        body = json.dumps(payload)
+    if not isinstance(body, bytes):
+        body = str.encode(body)
+    kwargs = {}
+    if AIOHTTP_VERSION >= StrictVersion('3.1.0'):
+        loop = Mock()
+        loop.get_debug = Mock()
+        loop.get_debug.return_value = True
+        kwargs['request_info'] = Mock()
+        kwargs['writer'] = Mock()
+        kwargs['continue100'] = None
+        kwargs['timer'] = TimerNoop()
+        if AIOHTTP_VERSION < StrictVersion('3.3.0'):
+            kwargs['auto_decompress'] = True
+        kwargs['traces'] = []
+        kwargs['loop'] = loop
+        kwargs['session'] = None
+    _headers = CIMultiDict({hdrs.CONTENT_TYPE: content_type})
+    if headers:
+        _headers.update(headers)
+    raw_headers = _build_raw_headers(_headers)
+    resp = response_class(method, url, **kwargs)
+    if AIOHTTP_VERSION >= StrictVersion('3.3.0'):
+        # Reified attributes
+        resp._headers = _headers
+        resp._raw_headers = raw_headers
+    else:
+        resp.headers = _headers
+        resp.raw_headers = raw_headers
+    resp.status = status
+    resp.reason = reason
+    resp.content = stream_reader_factory()
+    resp.content.feed_data(body)
+    resp.content.feed_eof()
+    return resp
+
+
 __all__ = [
     'URL',
     'Pattern',
@@ -56,4 +124,5 @@ __all__ = [
     'merge_params',
     'stream_reader_factory',
     'normalize_url',
+    'build_response',
 ]

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -4,7 +4,7 @@ import json
 from collections import namedtuple
 from distutils.version import StrictVersion
 from functools import wraps
-from typing import Dict, Tuple, Union, Optional, List  # noqa
+from typing import Callable, Dict, Tuple, Union, Optional, List  # noqa
 from unittest.mock import Mock, patch
 
 from aiohttp import (
@@ -41,7 +41,8 @@ class RequestMatch(object):
                  response_class: 'ClientResponse' = None,
                  timeout: bool = False,
                  repeat: bool = False,
-                 reason: Optional[str] = None):
+                 reason: Optional[str] = None,
+                 callback: Optional[Callable] = None):
         if isinstance(url, Pattern):
             self.url_or_pattern = url
             self.match_func = self.match_regexp
@@ -50,17 +51,14 @@ class RequestMatch(object):
             self.match_func = self.match_str
         self.method = method.lower()
         self.status = status
-        if payload is not None:
-            body = json.dumps(payload)
-        if not isinstance(body, bytes):
-            body = str.encode(body)
         self.body = body
+        self.payload = payload
         self.exception = exception
         if timeout:
             self.exception = asyncio.TimeoutError('Connection timeout test')
         self.headers = headers
         self.content_type = content_type
-        self.response_class = response_class or ClientResponse
+        self.response_class = response_class
         self.repeat = repeat
         self.reason = reason
         if self.reason is None:
@@ -68,6 +66,7 @@ class RequestMatch(object):
                 self.reason = http.RESPONSES[self.status][0]
             except (IndexError, KeyError):
                 self.reason = ''
+        self.callback = callback
 
     def match_str(self, url: URL) -> bool:
         return self.url_or_pattern == url
@@ -80,11 +79,22 @@ class RequestMatch(object):
             return False
         return self.match_func(url)
 
-    async def build_response(
-            self, url: URL
-    ) -> 'Union[ClientResponse, Exception]':
-        if isinstance(self.exception, Exception):
-            return self.exception
+    def build_response(
+            self, url: 'Union[URL, str]',
+            method: str = hdrs.METH_GET,
+            status: int = 200,
+            body: str = '',
+            content_type: str = 'application/json',
+            payload: Dict = None,
+            headers: Dict = None,
+            response_class: 'ClientResponse' = None,
+            reason: Optional[str] = None) -> ClientResponse:
+        if response_class is None:
+            response_class = ClientResponse
+        if payload is not None:
+            body = json.dumps(payload)
+        if not isinstance(body, bytes):
+            body = str.encode(body)
         kwargs = {}
         if AIOHTTP_VERSION >= StrictVersion('3.1.0'):
             loop = Mock()
@@ -94,31 +104,50 @@ class RequestMatch(object):
             kwargs['writer'] = Mock()
             kwargs['continue100'] = None
             kwargs['timer'] = TimerNoop()
-            if AIOHTTP_VERSION >= StrictVersion('3.3.0'):
-                pass
-            else:
+            if AIOHTTP_VERSION < StrictVersion('3.3.0'):
                 kwargs['auto_decompress'] = True
             kwargs['traces'] = []
             kwargs['loop'] = loop
             kwargs['session'] = None
-        resp = self.response_class(self.method, url, **kwargs)
-        # we need to initialize headers manually
-        headers = CIMultiDict({hdrs.CONTENT_TYPE: self.content_type})
-        if self.headers:
-            headers.update(self.headers)
-        raw_headers = self._build_raw_headers(headers)
+        _headers = CIMultiDict({hdrs.CONTENT_TYPE: content_type})
+        if headers:
+            _headers.update(headers)
+        raw_headers = self._build_raw_headers(_headers)
+        resp = response_class(method, url, **kwargs)
         if AIOHTTP_VERSION >= StrictVersion('3.3.0'):
             # Reified attributes
-            resp._headers = headers
+            resp._headers = _headers
             resp._raw_headers = raw_headers
         else:
-            resp.headers = headers
+            resp.headers = _headers
             resp.raw_headers = raw_headers
-        resp.status = self.status
-        resp.reason = self.reason
+        resp.status = status
+        resp.reason = reason
         resp.content = stream_reader_factory()
-        resp.content.feed_data(self.body)
+        resp.content.feed_data(body)
         resp.content.feed_eof()
+        return resp
+
+    async def _build_response(
+            self, url: URL, *args: Tuple, **kwargs: Dict
+    ) -> 'Union[ClientResponse, Exception]':
+        if isinstance(self.exception, Exception):
+            return self.exception
+        if self.callback and callable(self.callback):
+            resp = await self.callback(self, url, *args, **kwargs)
+        else:
+            resp = None
+        if resp is None:
+            resp = self.build_response(
+                url=url,
+                method=self.method,
+                status=self.status,
+                body=self.body,
+                content_type=self.content_type,
+                payload=self.payload,
+                headers=self.headers,
+                response_class=self.response_class,
+                reason=self.reason)
         return resp
 
     def _build_raw_headers(self, headers: Dict) -> Tuple:
@@ -226,7 +255,8 @@ class aioresponses(object):
             response_class: 'ClientResponse' = None,
             repeat: bool = False,
             timeout: bool = False,
-            reason: Optional[str] = None) -> None:
+            reason: Optional[str] = None,
+            callback: Optional[Callable] = None) -> None:
         self._matches.append(RequestMatch(
             url,
             method=method,
@@ -240,12 +270,15 @@ class aioresponses(object):
             repeat=repeat,
             timeout=timeout,
             reason=reason,
+            callback=callback,
         ))
 
-    async def match(self, method: str, url: URL) -> Optional['ClientResponse']:
+    async def match(
+            self, method: str, url: URL, *args: Tuple, **kwargs: Dict
+    ) -> Optional['ClientResponse']:
         for i, matcher in enumerate(self._matches):
             if matcher.match(method, url):
-                response = await matcher.build_response(url)
+                response = await matcher._build_response(url, *args, **kwargs)
                 break
         else:
             return None
@@ -269,7 +302,7 @@ class aioresponses(object):
                     orig_self, method, url, *args, **kwargs
                 ))
 
-        response = await self.match(method, url)
+        response = await self.match(method, url, *args, **kwargs)
         if response is None:
             raise ClientConnectionError(
                 'Connection refused: {} {}'.format(method, url)

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 import asyncio
+import json
 from collections import namedtuple
+from distutils.version import StrictVersion
 from functools import wraps
 from typing import Callable, Dict, Tuple, Union, Optional, List  # noqa
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from aiohttp import (
     ClientConnectionError,
@@ -12,14 +14,37 @@ from aiohttp import (
     hdrs,
     http
 )
+from aiohttp.helpers import TimerNoop
+from multidict import CIMultiDict
 
 from .compat import (
+    AIOHTTP_VERSION,
     URL,
     Pattern,
+    stream_reader_factory,
     merge_params,
     normalize_url,
-    build_response,
 )
+
+
+class CallbackResult:
+
+    def __init__(self, method: str = hdrs.METH_GET,
+                 status: int = 200,
+                 body: str = '',
+                 content_type: str = 'application/json',
+                 payload: Dict = None,
+                 headers: Dict = None,
+                 response_class: 'ClientResponse' = None,
+                 reason: Optional[str] = None):
+        self.method = method
+        self.status = status
+        self.body = body
+        self.content_type = content_type
+        self.payload = payload
+        self.headers = headers
+        self.response_class = response_class
+        self.reason = reason
 
 
 class RequestMatch(object):
@@ -74,31 +99,86 @@ class RequestMatch(object):
             return False
         return self.match_func(url)
 
-    async def _build_response(
+    def _build_raw_headers(self, headers: Dict) -> Tuple:
+        """
+        Convert a dict of headers to a tuple of tuples
+
+        Mimics the format of ClientResponse.
+        """
+        raw_headers = []
+        for k, v in headers.items():
+            raw_headers.append((k.encode('utf8'), v.encode('utf8')))
+        return tuple(raw_headers)
+
+    def _build_response(self, url: 'Union[URL, str]',
+                        method: str = hdrs.METH_GET,
+                        status: int = 200,
+                        body: str = '',
+                        content_type: str = 'application/json',
+                        payload: Dict = None,
+                        headers: Dict = None,
+                        response_class: 'ClientResponse' = None,
+                        reason: Optional[str] = None) -> ClientResponse:
+        if response_class is None:
+            response_class = ClientResponse
+        if payload is not None:
+            body = json.dumps(payload)
+        if not isinstance(body, bytes):
+            body = str.encode(body)
+        kwargs = {}
+        if AIOHTTP_VERSION >= StrictVersion('3.1.0'):
+            loop = Mock()
+            loop.get_debug = Mock()
+            loop.get_debug.return_value = True
+            kwargs['request_info'] = Mock()
+            kwargs['writer'] = Mock()
+            kwargs['continue100'] = None
+            kwargs['timer'] = TimerNoop()
+            if AIOHTTP_VERSION < StrictVersion('3.3.0'):
+                kwargs['auto_decompress'] = True
+            kwargs['traces'] = []
+            kwargs['loop'] = loop
+            kwargs['session'] = None
+        # We need to initialize headers manually
+        _headers = CIMultiDict({hdrs.CONTENT_TYPE: content_type})
+        if headers:
+            _headers.update(headers)
+        raw_headers = self._build_raw_headers(_headers)
+        resp = response_class(method, url, **kwargs)
+        if AIOHTTP_VERSION >= StrictVersion('3.3.0'):
+            # Reified attributes
+            resp._headers = _headers
+            resp._raw_headers = raw_headers
+        else:
+            resp.headers = _headers
+            resp.raw_headers = raw_headers
+        resp.status = status
+        resp.reason = reason
+        resp.content = stream_reader_factory()
+        resp.content.feed_data(body)
+        resp.content.feed_eof()
+        return resp
+
+    async def build_response(
             self, url: URL, **kwargs: Dict
     ) -> 'Union[ClientResponse, Exception]':
         if isinstance(self.exception, Exception):
             return self.exception
         if callable(self.callback):
-            resp = self.callback(url, **kwargs)
+            result = self.callback(url, **kwargs)
         else:
-            resp = None
-        if resp is None:
-            url = url
-            resp_data = self
-        else:
-            url = resp.url
-            resp_data = resp
-        resp = build_response(
+            result = None
+        result = self if result is None else result
+        resp = self._build_response(
             url=url,
-            method=resp_data.method,
-            status=resp_data.status,
-            body=resp_data.body,
-            content_type=resp_data.content_type,
-            payload=resp_data.payload,
-            headers=resp_data.headers,
-            response_class=resp_data.response_class,
-            reason=resp_data.reason)
+            method=result.method,
+            status=result.status,
+            body=result.body,
+            content_type=result.content_type,
+            payload=result.payload,
+            headers=result.headers,
+            response_class=result.response_class,
+            reason=result.reason)
         return resp
 
 
@@ -218,7 +298,7 @@ class aioresponses(object):
     ) -> Optional['ClientResponse']:
         for i, matcher in enumerate(self._matches):
             if matcher.match(method, url):
-                response = await matcher._build_response(url, **kwargs)
+                response = await matcher.build_response(url, **kwargs)
                 break
         else:
             return None

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from aiohttp import (
     ClientConnectionError,
+    ClientResponse,
     ClientSession,
     hdrs,
     http
@@ -83,16 +84,21 @@ class RequestMatch(object):
         else:
             resp = None
         if resp is None:
-            resp = build_response(
-                url=url,
-                method=self.method,
-                status=self.status,
-                body=self.body,
-                content_type=self.content_type,
-                payload=self.payload,
-                headers=self.headers,
-                response_class=self.response_class,
-                reason=self.reason)
+            url = url
+            resp_data = self
+        else:
+            url = resp.url
+            resp_data = resp
+        resp = build_response(
+            url=url,
+            method=resp_data.method,
+            status=resp_data.status,
+            body=resp_data.body,
+            content_type=resp_data.content_type,
+            payload=resp_data.payload,
+            headers=resp_data.headers,
+            response_class=resp_data.response_class,
+            reason=resp_data.reason)
         return resp
 
 

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -314,3 +314,19 @@ class AIOResponsesTestCase(TestCase):
 
         with self.assertRaises(asyncio.TimeoutError):
             self.run_async(self.request(self.url))
+
+    @aioresponses()
+    def test_callback(self, m):
+        body = b'New body'
+
+        @asyncio.coroutine
+        async def callback(match, url, *args, **kwargs):
+            self.assertEqual(str(url), self.url)
+            self.assertEqual(args, ())
+            self.assertEqual(kwargs, {'allow_redirects': True})
+            return match.build_response(url, body=body)
+
+        m.get(self.url, callback=callback)
+        response = self.run_async(self.request(self.url))
+        data = self.run_async(response.read())
+        assert data == body

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -322,7 +322,7 @@ class AIOResponsesTestCase(TestCase):
         def callback(url, **kwargs):
             self.assertEqual(str(url), self.url)
             self.assertEqual(kwargs, {'allow_redirects': True})
-            return CallbackResult(url, body=body)
+            return CallbackResult(body=body)
 
         m.get(self.url, callback=callback)
         response = self.run_async(self.request(self.url))

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -25,7 +25,7 @@ except ImportError:
     )
     from aiohttp.http_exceptions import HttpProcessingError
 
-from aioresponses.compat import URL
+from aioresponses.compat import URL, build_response
 from aioresponses import aioresponses
 
 
@@ -319,12 +319,10 @@ class AIOResponsesTestCase(TestCase):
     def test_callback(self, m):
         body = b'New body'
 
-        @asyncio.coroutine
-        async def callback(match, url, *args, **kwargs):
+        def callback(url, **kwargs):
             self.assertEqual(str(url), self.url)
-            self.assertEqual(args, ())
             self.assertEqual(kwargs, {'allow_redirects': True})
-            return match.build_response(url, body=body)
+            return build_response(url, body=body)
 
         m.get(self.url, callback=callback)
         response = self.run_async(self.request(self.url))

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -25,8 +25,8 @@ except ImportError:
     )
     from aiohttp.http_exceptions import HttpProcessingError
 
-from aioresponses.compat import URL, build_response
-from aioresponses import aioresponses
+from aioresponses.compat import URL
+from aioresponses import CallbackResult, aioresponses
 
 
 @ddt
@@ -322,7 +322,7 @@ class AIOResponsesTestCase(TestCase):
         def callback(url, **kwargs):
             self.assertEqual(str(url), self.url)
             self.assertEqual(kwargs, {'allow_redirects': True})
-            return build_response(url, body=body)
+            return CallbackResult(url, body=body)
 
         m.get(self.url, callback=callback)
         response = self.run_async(self.request(self.url))

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist =
     py35-aiohttp{20,21,22,23,30,31,32,33,34,35}
     py36-aiohttp-master
     py36-aiohttp{20,21,22,23,30,31,32,33,34,35}
+    py37-aiohttp-master
+    py37-aiohttp{20,21,22,23,30,31,32,33,34,35}
 skipsdist = True
 
 [testenv:flake8]
@@ -38,6 +40,7 @@ deps =
 basepython =
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 
 commands = python setup.py test
 


### PR DESCRIPTION
Callback's arguments are `URL` object and `aiohttp.ClientRequest` **kwargs.

Callback should return `CallbackResult` object. If callback returns `None` then default response will be built automatically (useful for just checking `aiohttp.ClientRequest` **kwargs).

Closes #15