### PR TITLE
Improve compat code

### DIFF
--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import asyncio  # noqa
-import re
+import asyncio  # noqa: F401
+import sys
 from distutils.version import StrictVersion
 from typing import Dict, Optional, Tuple, Union  # noqa
 from urllib.parse import parse_qsl, urlencode
@@ -9,11 +9,10 @@ from aiohttp import __version__ as aiohttp_version, StreamReader
 from multidict import MultiDict
 from yarl import URL
 
-try:
-    Pattern = re._pattern_type
-except AttributeError:  # pragma: no cover
-    # Python 3.7
-    Pattern = re.Pattern
+if sys.version_info < (3, 7):
+    from re import _pattern_type as Pattern
+else:
+    from re import Pattern
 
 AIOHTTP_VERSION = StrictVersion(aiohttp_version)
 
@@ -26,7 +25,7 @@ if AIOHTTP_VERSION >= StrictVersion('3.0.0'):
         protocol = ResponseHandler(loop=loop)
         return StreamReader(protocol)
 
-else:  # pragma: no cover
+else:
 
     def stream_reader_factory():
         return StreamReader()


### PR DESCRIPTION
- use explicit code with "noqa"
- use explicit version check, which makes it clearer what version it is
  used with (for easier removal)
- remove "pragma: no cover" - I can see that coverage is only run with
  py37, but it should be reported correctly when using other versions,
  and should rather be combined from multiple jobs on CI.