### PR TITLE
Allow getting mocked requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,6 +213,31 @@ for convenience use *payload* argument to mock out json response. Example below.
         assert resp.status == 418
 
 
+**aioresponses allows to get the mocked requests**
+
+.. code:: python
+
+    import asyncio
+    import aiohttp
+    from aioresponses import aioresponses
+
+    @aioresponses()
+    def test_requests(m):
+        loop = asyncio.get_event_loop()
+        session = aiohttp.ClientSession()
+
+        matcher = m.post('http://example.com', status=500)
+        m.post('http://example.com', status=200)
+
+        loop.run_until_complete(session.post('http://example.com', json={"a": 1}))
+        loop.run_until_complete(session.post('http://example.com', json={"a": 2}))
+
+        requests = aioresponses.matched_requests(matcher)
+        assert requests[0].kwargs["json"] == {"a": 1}
+        assert requests[1].kwargs["json"] == {"a": 2}
+
+
+
 **aioresponses can be used in a pytest fixture**
 
 .. code:: python

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -320,6 +320,15 @@ class aioresponses(object):
             raise response
         return response
 
+    def matched_requests(self, matcher: RequestMatch) -> List[RequestCall]:
+        matched = []
+
+        for key, requests in self.requests.items():
+            if matcher.match(*key):
+                matched.extend(requests)
+
+        return matched
+
     async def _request_mock(self, orig_self: ClientSession,
                             method: str, url: 'Union[URL, str]',
                             *args: Tuple,

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -321,6 +321,29 @@ class aioresponses(object):
         return response
 
     def matched_requests(self, matcher: RequestMatch) -> List[RequestCall]:
+        """
+        Given a RequestMatch, return all mocked requests that
+        matched this matcher.
+
+        Example:
+
+        loop = asyncio.get_event_loop()
+        session = aiohttp.ClientSession()
+
+        matcher = m.post('http://example.com', status=500)
+        m.post('http://example.com', status=200)
+
+        loop.run_until_complete(
+            session.post('http://example.com', json={"a": 1})
+        )
+        loop.run_until_complete(
+            session.post('http://example.com', json={"a": 2})
+        )
+
+        requests = aioresponses.matched_requests(matcher)
+        assert requests[0].kwargs["json"] == {"a": 1}
+        assert requests[1].kwargs["json"] == {"a": 2}
+        """
         matched = []
 
         for key, requests in self.requests.items():

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -249,26 +249,30 @@ class aioresponses(object):
         self.patcher.stop()
         self.clear()
 
-    def head(self, url: 'Union[URL, str, Pattern]', **kwargs):
-        self.add(url, method=hdrs.METH_HEAD, **kwargs)
+    def head(self, url: 'Union[URL, str, Pattern]', **kwargs) -> RequestMatch:
+        return self.add(url, method=hdrs.METH_HEAD, **kwargs)
 
-    def get(self, url: 'Union[URL, str, Pattern]', **kwargs):
-        self.add(url, method=hdrs.METH_GET, **kwargs)
+    def get(self, url: 'Union[URL, str, Pattern]', **kwargs) -> RequestMatch:
+        return self.add(url, method=hdrs.METH_GET, **kwargs)
 
-    def post(self, url: 'Union[URL, str, Pattern]', **kwargs):
-        self.add(url, method=hdrs.METH_POST, **kwargs)
+    def post(self, url: 'Union[URL, str, Pattern]', **kwargs) -> RequestMatch:
+        return self.add(url, method=hdrs.METH_POST, **kwargs)
 
-    def put(self, url: 'Union[URL, str, Pattern]', **kwargs):
-        self.add(url, method=hdrs.METH_PUT, **kwargs)
+    def put(self, url: 'Union[URL, str, Pattern]', **kwargs) -> RequestMatch:
+        return self.add(url, method=hdrs.METH_PUT, **kwargs)
 
-    def patch(self, url: 'Union[URL, str, Pattern]', **kwargs):
-        self.add(url, method=hdrs.METH_PATCH, **kwargs)
+    def patch(self, url: 'Union[URL, str, Pattern]', **kwargs) -> RequestMatch:
+        return self.add(url, method=hdrs.METH_PATCH, **kwargs)
 
-    def delete(self, url: 'Union[URL, str, Pattern]', **kwargs):
-        self.add(url, method=hdrs.METH_DELETE, **kwargs)
+    def delete(
+        self, url: 'Union[URL, str, Pattern]', **kwargs
+    ) -> RequestMatch:
+        return self.add(url, method=hdrs.METH_DELETE, **kwargs)
 
-    def options(self, url: 'Union[URL, str, Pattern]', **kwargs):
-        self.add(url, method=hdrs.METH_OPTIONS, **kwargs)
+    def options(
+        self, url: 'Union[URL, str, Pattern]', **kwargs
+    ) -> RequestMatch:
+        return self.add(url, method=hdrs.METH_OPTIONS, **kwargs)
 
     def add(self, url: 'Union[URL, str, Pattern]', method: str = hdrs.METH_GET,
             status: int = 200,
@@ -281,8 +285,8 @@ class aioresponses(object):
             repeat: bool = False,
             timeout: bool = False,
             reason: Optional[str] = None,
-            callback: Optional[Callable] = None) -> None:
-        self._matches.append(RequestMatch(
+            callback: Optional[Callable] = None) -> RequestMatch:
+        match = RequestMatch(
             url,
             method=method,
             status=status,
@@ -296,7 +300,9 @@ class aioresponses(object):
             timeout=timeout,
             reason=reason,
             callback=callback,
-        ))
+        )
+        self._matches.append(match)
+        return match
 
     async def match(
             self, method: str, url: URL, **kwargs: Dict

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -25,8 +25,9 @@ except ImportError:
     )
     from aiohttp.http_exceptions import HttpProcessingError
 
-from aioresponses.compat import AIOHTTP_VERSION, URL
 from aioresponses import CallbackResult, aioresponses
+from aioresponses.compat import AIOHTTP_VERSION, URL
+from aioresponses.core import RequestCall
 
 
 @ddt
@@ -362,6 +363,45 @@ class AIOResponsesTestCase(TestCase):
         response = future.result()
         data = self.run_async(response.read())
         assert data == body
+
+    @aioresponses()
+    @asyncio.coroutine
+    def test_matched_requests(self, mocked):
+        matcher_1 = mocked.get(
+            re.compile(r'^http://example\.com/api\?foo=.*$'),
+            status=200
+        )
+
+        matcher_2 = mocked.get(
+            re.compile(r'^http://example\.com/api\?foo=.*$'),
+            status=200
+        )
+
+        matcher_3 = mocked.get('http://example.com/other_api?foo=c', status=200)
+
+        url_1 = 'http://example.com/api'
+        url_3 = 'http://example.com/other_api'
+
+        yield from self.session.get(url_1, params={"foo": "a"})
+        yield from self.session.get(url_1, params={"foo": "b"})
+        yield from self.session.get(url_3, params={"foo": "c"})
+
+        # matcher 1 and 2 match the same requests,
+        # since they have the same regex as key
+        matched_1 = mocked.matched_requests(matcher_1)
+        matched_2 = mocked.matched_requests(matcher_2)
+        expected = [
+            RequestCall(tuple(), {"allow_redirects": True, "params": {"foo": "a"}}),
+            RequestCall(tuple(), {"allow_redirects": True, "params": {"foo": "b"}}),
+        ]
+        assert matched_1 == expected
+        assert matched_2 == expected
+
+        # matcher 3 matches another set of requests
+        matched_3 = mocked.matched_requests(matcher_3)
+        assert matched_3 == [
+            RequestCall(tuple(), {"allow_redirects": True, "params": {"foo": "c"}}),
+        ]
 
 
 class AIOResponsesRaiseForStatusSessionTestCase(TestCase):


### PR DESCRIPTION
Sometimes it is useful to get the requests that were made in order to check for certain arguments such as header and payload. Currently, `aioresponses` lets us do this by indexing into `aioresponses.requests` with a `(method, url)`. However, I find this a bit clunky to use, especially when the mocked url is a regex.

This PR includes a new way of getting the requests by using the `RequestMatch` object that is created when defining the mock. This is done by making the mocking methods return the created `RequestMatch` and by adding a new `.matched_requests()` that takes this match objects and uses it to search for matching requests on `aioresponses.requests`.

Example:

``` python
        loop = asyncio.get_event_loop()
        session = aiohttp.ClientSession()

        matcher = m.post('http://example.com', status=500)
        m.post('http://example.com', status=200)

        loop.run_until_complete(
            session.post('http://example.com', json={"a": 1})
        )
        loop.run_until_complete(
            session.post('http://example.com', json={"a": 2})
        )

        requests = aioresponses.matched_requests(matcher)
        assert requests[0].kwargs["json"] == {"a": 1}
        assert requests[1].kwargs["json"] == {"a": 2}
```

This is my first PR to this project, please let me know if there is any way it can be improved.