### PR TITLE
Add a get_active method to return the currently activate aioresponse

### DIFF
--- a/aioresponses/__init__.py
+++ b/aioresponses/__init__.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-from .core import CallbackResult, aioresponses
+from .core import CallbackResult, aioresponses, get_active
 
 __version__ = '0.4.1'
 
 __all__ = [
     'CallbackResult',
     'aioresponses',
+    'get_active'
 ]

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -242,6 +242,7 @@ class aioresponses(object):
         self._matches = []
         self.patcher.start()
         self.patcher.return_value = self._request_mock
+        self.patcher._aioresponse = self
 
     def stop(self) -> None:
         for response in self._responses:
@@ -351,3 +352,11 @@ class aioresponses(object):
             response.raise_for_status()
 
         return response
+
+
+def get_active() -> aioresponses:
+    from aiohttp.client import ClientSession
+    response = getattr(ClientSession._request, "_aioresponse")
+    if response is None:
+        raise ValueError("No active aioresponse mock")
+    return response

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -356,7 +356,7 @@ class aioresponses(object):
 
 def get_active() -> aioresponses:
     from aiohttp.client import ClientSession
-    response = getattr(ClientSession._request, "_aioresponse")
+    response = getattr(ClientSession._request, "_aioresponse", None)
     if response is None:
         raise ValueError("No active aioresponse mock")
     return response

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -26,7 +26,7 @@ except ImportError:
     from aiohttp.http_exceptions import HttpProcessingError
 
 from aioresponses.compat import AIOHTTP_VERSION, URL
-from aioresponses import CallbackResult, aioresponses
+from aioresponses import CallbackResult, aioresponses, get_active
 
 
 @ddt
@@ -362,6 +362,17 @@ class AIOResponsesTestCase(TestCase):
         response = future.result()
         data = self.run_async(response.read())
         assert data == body
+
+    def test_get_active_fails(self):
+        with self.assertRaises(ValueError, msg="No active aioresponse mock"):
+            get_active()
+
+    def test_get_active_works(self):
+        with aioresponses() as m1:
+            assert get_active() is m1
+
+        with aioresponses() as m2:
+            assert get_active() is m2
 
 
 class AIOResponsesRaiseForStatusSessionTestCase(TestCase):


### PR DESCRIPTION
This PR adds a single `aioresponse` fixture that can be used with Pytest.

## Why?

You currently cannot have two active `aioresponse` mocks. This is usually fine, but there are edge cases where this is annoying.

Imagine you have a library that provides a Pytest fixture, `mock_client`. This fixture needs to use `aioresponses` to mock an expected call that the client will make - the details of which are opaque to the user of the `mock_client`.

The simple implementation of this would be:

```python
@pytest.fixture()
def mock_client():
        with aioresponses() as m:
            m.get("http://my-service/my-url", status=200)
            yield FakeClient()
```

This would work, except if the consumer of the `mock_client` fixture *also* uses `aioresponses`. This would basically end up with two `with aioresponses()` being used, which conflict.

So, the solution is to be able to get the active `aioresponse` mock:

```python
@pytest.fixture()
def mock_client():
        mock = aioresponse.get_active()
        mock.get("http://my-service/my-url", status=200)
        yield FakeClient()
```