### PR TITLE
Save every received request. Even when no response is subscribed.

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -328,14 +328,16 @@ class aioresponses(object):
                 ))
 
         response = await self.match(method, url, **kwargs)
+
+        key = (method, url)
+        self.requests.setdefault(key, [])
+        self.requests[key].append(RequestCall(args, kwargs))
+
         if response is None:
             raise ClientConnectionError(
                 'Connection refused: {} {}'.format(method, url)
             )
         self._responses.append(response)
-        key = (method, url)
-        self.requests.setdefault(key, [])
-        self.requests[key].append(RequestCall(args, kwargs))
 
         # Automatically call response.raise_for_status() on a request if the
         # request was initialized with raise_for_status=True. Also call

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -250,6 +250,19 @@ class AIOResponsesTestCase(TestCase):
                              {'allow_redirects': True})
 
     @asyncio.coroutine
+    def test_request_retrieval_in_case_no_response(self):
+        with aioresponses() as m:
+            with self.assertRaises(ClientConnectionError):
+                yield from self.session.get(self.url)
+
+            key = ('GET', URL(self.url))
+            self.assertIn(key, m.requests)
+            self.assertEqual(len(m.requests[key]), 1)
+            self.assertEqual(m.requests[key][0].args, tuple())
+            self.assertEqual(m.requests[key][0].kwargs,
+                             {'allow_redirects': True})
+
+    @asyncio.coroutine
     def test_address_as_instance_of_url_combined_with_pass_through(self):
         external_api = 'http://httpbin.org/status/201'
 


### PR DESCRIPTION
The issue is that currently there is no way to retrieve received queries if no response is subscribed.

Making it impossible to test exception throwing not coming from a HTTP response.