### PR TITLE
Send a RuntimeError indicating that session is closed

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,7 +101,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
+3. The pull request should work for Python 3.5, 3.6, 3.7 and for PyPy. Check
    https://travis-ci.org/pnuckowski/aioresponses/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -319,6 +319,9 @@ class aioresponses(object):
                             *args: Tuple,
                             **kwargs: Dict) -> 'ClientResponse':
         """Return mocked response object or raise connection error."""
+        if orig_self.closed:
+            raise RuntimeError('Session is closed')
+
         url = normalize_url(merge_params(url, kwargs.get('params')))
         url_str = str(url)
         for prefix in self._passthrough:

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -262,6 +262,18 @@ class AIOResponsesTestCase(TestCase):
             self.assertEqual(m.requests[key][0].kwargs,
                              {'allow_redirects': True})
 
+    async def test_request_failure_in_case_session_is_closed(self):
+        async def do_request(session):
+            return await session.get(self.url)
+
+        with aioresponses():
+            async with ClientSession() as session:
+                coro = do_request(session)
+
+            with self.assertRaises(RuntimeError) as exception_info:
+                await coro
+            assert str(exception_info.exception) == "Session is closed"
+
     @asyncio.coroutine
     def test_address_as_instance_of_url_combined_with_pass_through(self):
         external_api = 'http://httpbin.org/status/201'


### PR DESCRIPTION
To behave the same way as [aiohttp](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client.py#L321)

I also took the liberty to keep the contributing doc up to date.

Note that I am not sure you should check for Python 3.5 compatibility as it was dropped by [aiohttp](https://github.com/aio-libs/aiohttp/blob/master/setup.py#L105).
And maybe it can be good to add explicit support for Python 3.8 :)

Thanks again for the great lib