### PR TITLE
Prevent saved requests to be modified

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import asyncio
 import json
+import copy
 from collections import namedtuple
 from distutils.version import StrictVersion
 from functools import wraps
@@ -334,7 +335,7 @@ class aioresponses(object):
 
         key = (method, url)
         self.requests.setdefault(key, [])
-        self.requests[key].append(RequestCall(args, kwargs))
+        self.requests[key].append(RequestCall(args, copy.deepcopy(kwargs)))
 
         if response is None:
             raise ClientConnectionError(


### PR DESCRIPTION
As kwargs are stored as is, they store references that might be updated, so the stored request might contains something else than the request that should have been sent.

Storing a deep copy of kwargs solves this.

I updated an already existing test case but if you'd rather want me to write a new one I can as well.

Also, would it be possible to plan a release on pypi?

Thanks again