### PR TITLE
Avoid failure in case one of the request arguments cannot be deep copied

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -353,7 +353,12 @@ class aioresponses(object):
 
         key = (method, url)
         self.requests.setdefault(key, [])
-        self.requests[key].append(RequestCall(args, copy.deepcopy(kwargs)))
+        try:
+            kwargs_copy = copy.deepcopy(kwargs)
+        except TypeError:
+            # Handle the fact that some values cannot be deep copied
+            kwargs_copy = kwargs
+        self.requests[key].append(RequestCall(args, kwargs_copy))
 
         if response is None:
             raise ClientConnectionError(


### PR DESCRIPTION
fixes #149 

Note that a clean fix would be to store something closer to the actually sent request but this is a quick fix for regression introduced by #143 