### PR TITLE
Fixes/duplication query params if url in passthrough

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -341,12 +341,13 @@ class aioresponses(object):
         if orig_self.closed:
             raise RuntimeError('Session is closed')
 
+        url_origin = url
         url = normalize_url(merge_params(url, kwargs.get('params')))
         url_str = str(url)
         for prefix in self._passthrough:
             if url_str.startswith(prefix):
                 return (await self.patcher.temp_original(
-                    orig_self, method, url, *args, **kwargs
+                    orig_self, method, url_origin, *args, **kwargs
                 ))
 
         response = await self.match(method, url, **kwargs)

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -311,6 +311,23 @@ class AIOResponsesTestCase(TestCase):
             self.assertEqual(api.status, 200)
             self.assertEqual(ext.status, 201)
 
+    @asyncio.coroutine
+    def test_pass_through_with_origin_params(self):
+        external_api = 'http://httpbin.org/get'
+
+        @asyncio.coroutine
+        def doit(params):
+            # we have to hit actual url,
+            # otherwise we do not test pass through option properly
+            ext_rep = yield from self.session.get(URL(external_api), params=params)
+            return ext_rep
+
+        with aioresponses(passthrough=[external_api]) as m:
+            params = {'1': 1}
+            ext = yield from doit(params=params)
+            self.assertEqual(ext.status, 200)
+            self.assertEqual(str(ext.url), 'http://httpbin.org/get?1=1')
+
     @aioresponses()
     @asyncio.coroutine
     def test_custom_response_class(self, m):

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -319,14 +319,14 @@ class AIOResponsesTestCase(TestCase):
         def doit(params):
             # we have to hit actual url,
             # otherwise we do not test pass through option properly
-            ext_rep = yield from self.session.get(URL(external_api), params=params)
+            ext_rep = (yield from self.session.get(URL(external_api), params=params))
             return ext_rep
 
         with aioresponses(passthrough=[external_api]) as m:
-            params = {'1': 1}
+            params = {'foo': 'bar'}
             ext = yield from doit(params=params)
             self.assertEqual(ext.status, 200)
-            self.assertEqual(str(ext.url), 'http://httpbin.org/get?1=1')
+            self.assertEqual(str(ext.url), 'http://httpbin.org/get?foo=bar')
 
     @aioresponses()
     @asyncio.coroutine


### PR DESCRIPTION
i faced with some strange code behaviore

the example
```
async def test_request():
    url = 'https://httpbin.org'
    with aioresponses(passthrough=[url]) as m:
        params = {'1': '1'}
        async with aiohttp.ClientSession() as session:
            async with session.get(
                    url=url + '/get', params={'1': 1}
            ) as response:
                status = response.status
                json = await response.json()
                url = str(response.url)

        # as i expected
        assert status == 200
        assert json['args'] == params
        assert url == 'https://httpbin.org/get?1=1'

        # what actual get
        # assert status == 200
        # assert json['args'] == {'1': ['1', '1']} !!!!! not {'1': 1}
        # assert url == 'https://httpbin.org/get?1=1&1=1'

```
the reason of strange behavior
```
run aiohttp.ClientSession with modificated  url
url = normalize_url(merge_params(url, kwargs.get('params')))
....
execute with moodificated url
return (await self.patcher.temp_original(
                    orig_self, method, url, *args, **kwargs
                ))

```

changes
when mock is don't use -> use the original uel without params modification