### PR TITLE
fix: set request_info on response rather than a mock

### DIFF
--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -503,3 +503,30 @@ class AIOResponseRedirectTest(TestCase):
         rsps.get(self.url, status=307)
         response = yield from self.session.get(self.url, allow_redirects=True)
         self.assertEqual(str(response.url), self.url)
+
+    @aioresponses()
+    @asyncio.coroutine
+    @skipIf(condition=AIOHTTP_VERSION < '3.1.0',
+            reason='aiohttp<3.1.0 does not add request info on response')
+    def test_request_info(self, rsps):
+        rsps.get(self.url, status=200)
+
+        response = yield from self.session.get(self.url)
+
+        request_info = response.request_info
+        assert str(request_info.url) == self.url
+        assert request_info.headers == {}
+
+    @aioresponses()
+    @asyncio.coroutine
+    @skipIf(condition=AIOHTTP_VERSION < '3.1.0',
+            reason='aiohttp<3.1.0 does not add request info on response')
+    def test_request_info_with_original_request_headers(self, rsps):
+        headers = {"Authorization": "Bearer access-token"}
+        rsps.get(self.url, status=200)
+
+        response = yield from self.session.get(self.url, headers=headers)
+
+        request_info = response.request_info
+        assert str(request_info.url) == self.url
+        assert request_info.headers == headers


### PR DESCRIPTION
Mocking `request_info` on response fails request introspection on response:

```
$ python
Python 3.7.3 (default, Apr 17 2019, 16:27:36)
[Clang 10.0.0 (clang-1000.10.44.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import asyncio
>>> import aiohttp
>>> from aioresponses import aioresponses
>>>
>>> @aioresponses()
... async def main(mocked):
...     mocked.get("https://httpbin.org/get")
...     async with aiohttp.ClientSession() as session:
...         response = await session.get("https://httpbin.org/get")
...         print(dict(response.request_info.headers))
...
>>>
>>> asyncio.run(main())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hadrien/.pyenv/versions/3.7.3/lib/python3.7/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/Users/hadrien/.pyenv/versions/3.7.3/lib/python3.7/asyncio/base_events.py", line 584, in run_until_complete
    return future.result()
  File "/Users/hadrien/W/aioresponses/aioresponses/core.py", line 228, in wrapped
    return await f(*args, **kwargs)
  File "<stdin>", line 6, in main
TypeError: Mock.keys() returned a non-iterable (type Mock)
>>>
```
