### PR TITLE
Load response cookies from headers

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -155,6 +155,10 @@ class RequestMatch(object):
             _headers.update(headers)
         raw_headers = self._build_raw_headers(_headers)
         resp = response_class(method, url, **kwargs)
+
+        for hdr in _headers.getall(hdrs.SET_COOKIE, ()):
+            resp.cookies.load(hdr)
+
         if AIOHTTP_VERSION >= StrictVersion('3.3.0'):
             # Reified attributes
             resp._headers = _headers

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -96,6 +96,15 @@ class AIOResponsesTestCase(TestCase):
 
     @aioresponses()
     @asyncio.coroutine
+    def test_returned_response_cookies(self, m):
+        m.get(self.url,
+              headers={'Set-Cookie': 'cookie=value'})
+        response = yield from self.session.get(self.url)
+
+        self.assertEqual(response.cookies['cookie'].value, 'value')
+
+    @aioresponses()
+    @asyncio.coroutine
     def test_returned_response_raw_headers(self, m):
         m.get(self.url,
               content_type='text/html',


### PR DESCRIPTION
Closes #155 

Now, you can mock out response cookie using `Set-Cookie` header, for example:

```python
m.get(..., headers={'Set-Cookie': 'cookie=value'})
```
