### PR TITLE
Change method to GET for redirect after POST request.

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -350,6 +350,7 @@ class aioresponses(object):
                     break
                 history.append(response_or_exc)
                 url = URL(response_or_exc.headers[hdrs.LOCATION])
+                method = 'get'
                 continue
             else:
                 break

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -588,6 +588,24 @@ class AIOResponseRedirectTest(TestCase):
 
     @aioresponses()
     @asyncio.coroutine
+    def test_post_redirect_followed(self, rsps):
+        rsps.post(
+            self.url,
+            status=307,
+            headers={"Location": "https://httpbin.org"},
+        )
+        rsps.get("https://httpbin.org")
+        response = yield from self.session.post(
+            self.url, allow_redirects=True
+        )
+        self.assertEqual(response.status, 200)
+        self.assertEqual(str(response.url), "https://httpbin.org")
+        self.assertEqual(response.method, "get")
+        self.assertEqual(len(response.history), 1)
+        self.assertEqual(str(response.history[0].url), self.url)
+
+    @aioresponses()
+    @asyncio.coroutine
     def test_redirect_missing_mocked_match(self, rsps):
         rsps.get(
             self.url,


### PR DESCRIPTION
As far as I know, all redirects should be with GET method. So, if you make POST request and receive 3xx redirect to some URL, you need to make GET request to this URL.