### PR TITLE
Fix compatibility with aiohttp==3.7.0

### DIFF
--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -45,7 +45,7 @@ if AIOHTTP_VERSION >= StrictVersion('3.0.0'):
         loop: 'Optional[asyncio.AbstractEventLoop]' = None
     ):
         protocol = ResponseHandler(loop=loop)
-        return StreamReader(protocol, loop=loop)
+        return StreamReader(protocol, limit=2 ** 16, loop=loop)
 
 else:
 


### PR DESCRIPTION
The new version of aiohttp has made `limit` a required argument for the
StreamReader class. This change adds an explicit limit of 2 ** 16 which
is the same as what aiohttp uses internally.

Fixes #173