### PR TITLE
Deepcopy in _request_mock should handle ValueError alongside TypeError

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -382,7 +382,7 @@ class aioresponses(object):
         self.requests.setdefault(key, [])
         try:
             kwargs_copy = copy.deepcopy(kwargs)
-        except TypeError:
+        except (TypeError, ValueError):
             # Handle the fact that some values cannot be deep copied
             kwargs_copy = kwargs
         self.requests[key].append(RequestCall(args, kwargs_copy))


### PR DESCRIPTION
When the deepcopy is called in _request_mock (core.py line 384) there is the potential for a ValueError to be raised (e.g. when kwargs contains an io.BytesIO instance). Currently the logic only supports the handling of TypeError, so this PR now allows the same behaviour on ValueError.