### PR TITLE
Feature: pass a custom delay to aioresponses to make it wait

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,26 @@ for convenience use *payload* argument to mock out json response. Example below.
         with aioresponses() as m:
             yield m
 
+**a custom delay in seconds can be passed to make aioresponses more realistically mimic a return call to the server**
+
+.. code:: python
+
+    import asyncio
+    import aiohttp
+    from aioresponses import aioresponses
+
+    @aioresponses()
+    def test_delay(m):
+        loop = asyncio.get_event_loop()
+        session = aiohttp.ClientSession()
+        m.get(
+            'http://example.com',
+            delay_seconds=0.3
+        )
+
+        resp = loop.run_until_complete(session.get('http://example.com'))
+        # Takes 300 ms to complete
+
 
 Features
 --------

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -65,7 +65,8 @@ class RequestMatch(object):
                  timeout: bool = False,
                  repeat: bool = False,
                  reason: Optional[str] = None,
-                 callback: Optional[Callable] = None):
+                 callback: Optional[Callable] = None,
+                 delay_seconds: float = None):
         if isinstance(url, Pattern):
             self.url_or_pattern = url
             self.match_func = self.match_regexp
@@ -84,6 +85,7 @@ class RequestMatch(object):
         self.response_class = response_class
         self.repeat = repeat
         self.reason = reason
+        self.delay_seconds = delay_seconds
         if self.reason is None:
             try:
                 self.reason = http.RESPONSES[self.status][0]
@@ -200,6 +202,10 @@ class RequestMatch(object):
             headers=result.headers,
             response_class=result.response_class,
             reason=result.reason)
+
+        if self.delay_seconds:
+            await asyncio.sleep(self.delay_seconds)
+
         return resp
 
 
@@ -297,7 +303,8 @@ class aioresponses(object):
             repeat: bool = False,
             timeout: bool = False,
             reason: Optional[str] = None,
-            callback: Optional[Callable] = None) -> None:
+            callback: Optional[Callable] = None,
+            delay_seconds: float = None) -> None:
 
         self._matches[str(uuid4())] = (RequestMatch(
             url,
@@ -313,6 +320,7 @@ class aioresponses(object):
             timeout=timeout,
             reason=reason,
             callback=callback,
+            delay_seconds=delay_seconds
         ))
 
     @staticmethod

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -171,9 +171,7 @@ class AIOResponsesTestCase(AsyncTestCase):
         delay_seconds = 1
         m.get(self.url, body='Test', delay_seconds=delay_seconds)
         now = time()
-        print(now)
         await self.session.get(self.url)
-        print(time() - now)
         assert time() - now >= delay_seconds
 
     async def test_mocking_as_context_manager(self):

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import asyncio
 import re
+from time import time
 from asyncio import CancelledError, TimeoutError
 from random import uniform
 from typing import Coroutine, Generator, Union
@@ -164,6 +165,16 @@ class AIOResponsesTestCase(AsyncTestCase):
         self.assertEqual(content, b'Te')
         content = await resp.content.read(2)
         self.assertEqual(content, b'st')
+
+    @aioresponses()
+    async def test_delay_seconds(self, m):
+        delay_seconds = 1
+        m.get(self.url, body='Test', delay_seconds=delay_seconds)
+        now = time()
+        print(now)
+        await self.session.get(self.url)
+        print(time() - now)
+        assert time() - now >= delay_seconds
 
     async def test_mocking_as_context_manager(self):
         with aioresponses() as aiomock:


### PR DESCRIPTION
Hi,

I came across a use case where we had to mimic a delay in a request returning and couldn't find a way to add it, so I added it to my fork. Not sure if this was required or already a feature request, but in case it is deemed useful this PR can be merged. If not, just close it. 

Cheers!