### PR TITLE
Fix setuptools warnings by replacing dashes in keys with underscores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = aioresponses
 author = Pawel Nuckowski
-author-email = p.nuckowski@gmail.com
+author_email = p.nuckowski@gmail.com
 summary = Mock out requests made by ClientSession from aiohttp package
-description-file = README.rst
-home-page = https://github.com/pnuckowski/aioresponses
+description_file = README.rst
+home_page = https://github.com/pnuckowski/aioresponses
 classifier =
   Development Status :: 4 - Beta
   Intended Audience :: Developers


### PR DESCRIPTION
Hi,
The current values emit warnings, e.g.:
> `UserWarning: Usage of dash-separated 'author-email' will not be supported in future versions. Please use the underscore name 'author_email' instead`