### PR TITLE
Allow for callbacks to be called before raising of exceptions

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -178,9 +178,6 @@ class RequestMatch(object):
     async def build_response(
         self, url: URL, **kwargs
     ) -> 'Union[ClientResponse, Exception]':
-        if self.exception is not None:
-            return self.exception
-
         if callable(self.callback):
             if asyncio.iscoroutinefunction(self.callback):
                 result = await self.callback(url, **kwargs)
@@ -188,6 +185,10 @@ class RequestMatch(object):
                 result = self.callback(url, **kwargs)
         else:
             result = None
+
+        if self.exception is not None:
+            return self.exception
+
         result = self if result is None else result
         resp = self._build_response(
             url=url,

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -251,6 +251,15 @@ class AIOResponsesTestCase(AsyncTestCase):
             with self.assertRaises(HttpProcessingError):
                 await self.session.get(url)
 
+            callback_called = asyncio.Event()
+            url = 'http://example.com/HttpProcessingError'
+            aiomock.get(url, exception=HttpProcessingError(message='foo'),
+                        callback=lambda *_, **__: callback_called.set())
+            with self.assertRaises(HttpProcessingError):
+                await self.session.get(url)
+            
+            await callback_called.wait()
+
     async def test_multiple_requests(self):
         """Ensure that requests are saved the way they would have been sent."""
         with aioresponses() as m:


### PR DESCRIPTION
This PR should allow callbacks to be called before exceptions are raised.

A possible use case is shown in the unit test, where a test would require an `asyncio.Event` to be set before proceeding.

@petioptrv, please do take a look at this PR. This should resolve the test case wrt the callback not releasing the `asyncio.Event` resulting in the test waiting indefinitely.