### PR TITLE
Fix type annotations

### DIFF
--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import asyncio  # noqa: F401
 import sys
-from typing import Dict, Optional, Tuple, Union  # noqa
+from typing import Dict, Optional, Union  # noqa
 from urllib.parse import parse_qsl, urlencode
 
 from aiohttp import __version__ as aiohttp_version, StreamReader
@@ -32,7 +32,10 @@ else:
         return StreamReader()
 
 
-def merge_params(url: 'Union[URL, str]', params: 'Dict' = None) -> 'URL':
+def merge_params(
+    url: 'Union[URL, str]',
+    params: Optional[Dict] = None
+) -> 'URL':
     url = URL(url)
     if params:
         query_params = MultiDict(url.query)


### PR DESCRIPTION
Unlike 0.7.2, the 0.7.3 release of `aioresponses` ships with the
`py.typed` file which means that `mypy` assumes the library is now fully
typed. This is beneficial for users for the library because they can use
static type checkers to ensure that they use it correctly. However, some
public functions in `aioresponses` are missing type annotations (e.g.,
`aioresponses.clear` or `aioresponses.__init__`) and some have incorrect
type annotations. As a result, projects which use `aioresponses` start
failing `mypy` checks when `aioresponses` is upgraded from 0.7.2 to
0.7.3. To fix that, we fix type annotations for public functions in
`aioresponses` by adding them where missing and by changing the ones
which are incorrect.

The incorrect type annotations which we fix are:

* Functions with the `response_class` argument expect a type, not an
  instance of the type, so we change `ClientResponse` to
  `Type[ClientResponse]`.
* Parameters which default to `None` should be typed as
  `Optional[Something]` because otherwise `mypy` not only reports errors
  when type checking the `aioresponse` library itself but also incorrectly
  infers types variables which users of the library may try to access.
* Some `**kwargs` arguments are typed `**kwargs: Dict` which is
  incorrect -- the type annotation should tell what the types of keyword
  arguments are, not what the type of the `kwargs` variable is. Keyword
  arguments in these functions are of a mixed type, not necessarily
  dictionaries, so we change the annotation from `Dict` to `Any`.

What we do in this change should be sufficient for projects relying on
the library to pass type checks. However, there's still a lot of issues
which `mypy` reports for `aioresponses` itself. We bring the number of
errors reported by `mypy --strict aioresponses` from 105 down to 58
which is good for now but there's still some work left to be done.

Closes #202