### PR TITLE
Include `py.typed` file in package build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,4 +10,6 @@ recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
+global-include *.typed
+
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif

--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,5 @@ import setuptools
 setuptools.setup(
     setup_requires=['pbr'],
     pbr=True,
+    package_data={"aioresponses": ["py.typed"]}
 )


### PR DESCRIPTION
Fixes #206 (see description and steps to reproduce there)
