### PR TITLE
Specify type of `stream_reader_factory`

### DIFF
--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import asyncio  # noqa: F401
 import sys
-from typing import Dict, Optional, Union  # noqa
+from typing import Dict, Optional, Union, Callable  # noqa
 from urllib.parse import parse_qsl, urlencode
 
 from aiohttp import __version__ as aiohttp_version, StreamReader
@@ -16,6 +16,7 @@ else:
 
 AIOHTTP_VERSION = parse_version(aiohttp_version)
 
+stream_reader_factory: Callable[[Optional[asyncio.AbstractEventLoop]], StreamReader]
 if AIOHTTP_VERSION >= parse_version('3.0.0'):
     from aiohttp.client_proto import ResponseHandler
 

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -16,7 +16,9 @@ else:
 
 AIOHTTP_VERSION = parse_version(aiohttp_version)
 
-stream_reader_factory: Callable[[Optional[asyncio.AbstractEventLoop]], StreamReader]
+stream_reader_factory: Callable[
+    [Optional[asyncio.AbstractEventLoop]], StreamReader
+]
 if AIOHTTP_VERSION >= parse_version('3.0.0'):
     from aiohttp.client_proto import ResponseHandler
 


### PR DESCRIPTION
Fixes mypy warning
> aioresponses\compat.py:31: error: All conditional function variants must have identical signatures  [misc]
