### PR TITLE
ignore false positive mypy warning when `url_or_pattern` is a `Pattern`

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -111,7 +111,9 @@ class RequestMatch(object):
 
     def match_regexp(self, url: URL) -> bool:
         # This method is used if and only if self.url_or_pattern is a pattern.
-        return bool(self.url_or_pattern.match(str(url)))  # type:ignore[union-attr]
+        return bool(
+            self.url_or_pattern.match(str(url))  # type:ignore[union-attr]
+        )
 
     def match(self, method: str, url: URL) -> bool:
         if self.method != method.lower():

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -110,7 +110,8 @@ class RequestMatch(object):
         return self.url_or_pattern == url
 
     def match_regexp(self, url: URL) -> bool:
-        return bool(self.url_or_pattern.match(str(url)))
+        # This method is used if and only if self.url_or_pattern is actually a pattern.
+        return bool(self.url_or_pattern.match(str(url)))  # type:ignore[union-attr]
 
     def match(self, method: str, url: URL) -> bool:
         if self.method != method.lower():

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -110,7 +110,7 @@ class RequestMatch(object):
         return self.url_or_pattern == url
 
     def match_regexp(self, url: URL) -> bool:
-        # This method is used if and only if self.url_or_pattern is actually a pattern.
+        # This method is used if and only if self.url_or_pattern is a pattern.
         return bool(self.url_or_pattern.match(str(url)))  # type:ignore[union-attr]
 
     def match(self, method: str, url: URL) -> bool:


### PR DESCRIPTION
Ignore:
> aioresponses\core.py:113: error: Item "URL" of "Union[URL, Pattern[Any]]" has no attribute "match"  [union-attr]
