### PR TITLE
Document repeat argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,30 @@ for convenience use *payload* argument to mock out json response. Example below.
         assert resp2.status == 200
 
 
+**Repeat response for the same url**  
+
+E.g. for cases you want to test retrying mechanisms
+
+.. code:: python
+
+    import asyncio
+    import aiohttp
+    from aioresponses import aioresponses
+
+    @aioresponses()
+    def test_multiple_responses(m):
+        loop = asyncio.get_event_loop()
+        session = aiohttp.ClientSession()
+        m.get('http://example.com', status=500, repeat=True)
+        m.get('http://example.com', status=200)  # will not take effect
+
+        resp1 = loop.run_until_complete(session.get('http://example.com'))
+        resp2 = loop.run_until_complete(session.get('http://example.com'))
+
+        assert resp1.status == 500
+        assert resp2.status == 500
+
+
 **match URLs with regular expressions**
 
 .. code:: python

--- a/docs/aioresponses.rst
+++ b/docs/aioresponses.rst
@@ -4,19 +4,26 @@ aioresponses package
 Submodules
 ----------
 
+aioresponses.compat module
+--------------------------
+
+.. automodule:: aioresponses.compat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 aioresponses.core module
 ------------------------
 
 .. automodule:: aioresponses.core
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Module contents
 ---------------
 
 .. automodule:: aioresponses
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Relates to https://github.com/pnuckowski/aioresponses/issues/164

Technical notes:
1. I had to upgrade sphinx to be able to generate the docs
2. I've tested the code with `conftest.py` with the aioresponses fixture being defined there - slightly different from the existing examples but it should not matter.