### PR TITLE
Fix double encoding of URLs in normalize_url

### DIFF
--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -2,7 +2,7 @@
 import asyncio  # noqa: F401
 import sys
 from typing import Dict, Optional, Union  # noqa
-from urllib.parse import parse_qsl, urlencode
+from urllib.parse import parse_qsl
 
 from aiohttp import __version__ as aiohttp_version, StreamReader
 from multidict import MultiDict
@@ -47,7 +47,7 @@ def merge_params(
 def normalize_url(url: 'Union[URL, str]') -> 'URL':
     """Normalize url to make comparisons."""
     url = URL(url)
-    return url.with_query(urlencode(sorted(parse_qsl(url.query_string))))
+    return url.with_query(sorted(parse_qsl(url.query_string)))
 
 
 try:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from ddt import ddt, data
 from yarl import URL
 
-from aioresponses.compat import merge_params
+from aioresponses.compat import merge_params, normalize_url
 
 
 def get_url(url: str, as_str: bool) -> Union[URL, str]:
@@ -19,6 +19,7 @@ class CompatTestCase(TestCase):
     def setUp(self):
         self.url_with_parameters = 'http://example.com/api?foo=bar#fragment'
         self.url_without_parameters = 'http://example.com/api?#fragment'
+        self.url_with_unsafe_chars_and_unordered_params = 'http://example.com/api?foo=bar&type=arg@&see:=thatagain'
 
     @data(True, False)
     def test_no_params_returns_same_url__as_str(self, as_str):
@@ -46,3 +47,9 @@ class CompatTestCase(TestCase):
         url = get_url(self.url_without_parameters, as_str)
 
         self.assertEqual(merge_params(url, {'x': 42}), expected_url)
+
+    def test_normalize_url(self):
+        self.assertEqual(
+            normalize_url(self.url_with_unsafe_chars_and_unordered_params),
+            URL('http://example.com/api?foo=bar&see:=thatagain&type=arg@')
+        )


### PR DESCRIPTION
Fix URLs being double encoded, as the yarl URL with_query method will
re-encode any % values.

Addresses #179.