### PR TITLE
Fix python versions in env list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  python-major-version: 3
+
 concurrency:
   group: ci-${{ github.ref }}-${{ github.actor }}
   cancel-in-progress: true
@@ -19,65 +22,65 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 3.6
+          - python-minor-version: 6
             aiohttp-version: aiohttp30
-          - python-version: 3.6
+          - python-minor-version: 6
             aiohttp-version: aiohttp31
-          - python-version: 3.6
+          - python-minor-version: 6
             aiohttp-version: aiohttp32
-          - python-version: 3.6
+          - python-minor-version: 6
             aiohttp-version: aiohttp33
-          - python-version: 3.6
+          - python-minor-version: 6
             aiohttp-version: aiohttp34
-          - python-version: 3.6
+          - python-minor-version: 6
             aiohttp-version: aiohttp35
-          - python-version: 3.6
+          - python-minor-version: 6
             aiohttp-version: aiohttp36
-          - python-version: 3.6
+          - python-minor-version: 6
             aiohttp-version: aiohttp37
 
-          - python-version: 3.7
+          - python-minor-version: 7
             aiohttp-version: aiohttp33
-          - python-version: 3.7
+          - python-minor-version: 7
             aiohttp-version: aiohttp34
-          - python-version: 3.7
+          - python-minor-version: 7
             aiohttp-version: aiohttp35
-          - python-version: 3.7
+          - python-minor-version: 7
             aiohttp-version: aiohttp36
-          - python-version: 3.7
+          - python-minor-version: 7
             aiohttp-version: aiohttp37
 
-          - python-version: 3.8
+          - python-minor-version: 8
             aiohttp-version: aiohttp33
-          - python-version: 3.8
+          - python-minor-version: 8
             aiohttp-version: aiohttp34
-          - python-version: 3.8
+          - python-minor-version: 8
             aiohttp-version: aiohttp35
-          - python-version: 3.8
+          - python-minor-version: 8
             aiohttp-version: aiohttp36
-          - python-version: 3.8
+          - python-minor-version: 8
             aiohttp-version: aiohttp37
 
-          - python-version: 3.9
+          - python-minor-version: 9
             aiohttp-version: aiohttp35
-          - python-version: 3.9
+          - python-minor-version: 9
             aiohttp-version: aiohttp36
-          - python-version: 3.9
+          - python-minor-version: 9
             aiohttp-version: aiohttp37
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ env.python-major-version }}.${{ matrix.python-minor-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ env.python-major-version }}.${{ matrix.python-minor-version }}
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
         pip install tox
     - name: Run Tests
       run: |
-        tox -e py${{ matrix.python-version }}-${{ matrix.aiohttp-version }}
+        tox -e py${{ env.python-major-version }}${{ matrix.python-version }}-${{ matrix.aiohttp-version }}
     - uses: codecov/codecov-action@v2
       with:
         file: coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 envlist =
     flake8,
     coverage,
-    py3.6-aiohttp{30,31,32,33,34,35,36,37}
-    py3.7-aiohttp{33,34,35,36,37}
-    py3.8-aiohttp{33,34,35,36,37}
-    py3.9-aiohttp{37}
+    py36-aiohttp{30,31,32,33,34,35,36,37}
+    py37-aiohttp{33,34,35,36,37}
+    py38-aiohttp{33,34,35,36,37}
+    py39-aiohttp{37}
 skipsdist = True
 
 [testenv:flake8]


### PR DESCRIPTION
Tox does not support a `.` between major and minor versions.  I am not clear on how CI runs are happening, but I am on version 3.25 and looking at source code, I don't see this supported.