### PR TITLE
Fix double-query-encoding bug

### DIFF
--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -47,7 +47,7 @@ def merge_params(
 def normalize_url(url: 'Union[URL, str]') -> 'URL':
     """Normalize url to make comparisons."""
     url = URL(url)
-    return url.with_query(urlencode(sorted(parse_qsl(url.query_string))))
+    return url.with_query(sorted(url.query.items()))
 
 
 try:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
+from itertools import product
 from typing import Union
 from unittest import TestCase
 
-from ddt import ddt, data
+from ddt import ddt, data, unpack
 from yarl import URL
 
-from aioresponses.compat import merge_params
+from aioresponses.compat import merge_params, normalize_url
 
 
 def get_url(url: str, as_str: bool) -> Union[URL, str]:
@@ -46,3 +47,46 @@ class CompatTestCase(TestCase):
         url = get_url(self.url_without_parameters, as_str)
 
         self.assertEqual(merge_params(url, {'x': 42}), expected_url)
+
+    @data(
+        *(
+            (original_url, expected_url, as_str)
+            for (original_url, expected_url), as_str
+            in product(
+                [
+                    (
+                            # Trivial example.
+                            "http://example.com/api?var2=baz&var1=foo",
+                            "http://example.com/api?var1=foo&var2=baz",
+                    ),
+                    (
+                            # Multi-occurrence of keys and proper query string encoding/decoding.
+                            "https://example.com/api?var3=gaz%3Bdar&var1=foo:bar&var1=bar/baz&var2=baz%26gaz",
+                            "https://example.com/api?var1=bar/baz&var1=foo:bar&var2=baz%26gaz&var3=gaz%3Bdar",
+                    ),
+                    (
+                            # Same as above, but input already encoded.
+                            "https://example.com/api?var3=gaz%3Bdar&var1=foo%3Abar&var1=bar%2Fbaz&var2=baz%26gaz",
+                            "https://example.com/api?var1=bar/baz&var1=foo:bar&var2=baz%26gaz&var3=gaz%3Bdar",
+                    ),
+                    (
+                            # Testing encoding/decoding for non-ascii characters.
+                            "https://example.com/api?var=путь",
+                            "https://example.com/api?var=%D0%BF%D1%83%D1%82%D1%8C",
+                    ),
+                    (
+                            # Same as above, but input already encoded.
+                            "https://example.com/api?var=%D0%BF%D1%83%D1%82%D1%8C",
+                            "https://example.com/api?var=%D0%BF%D1%83%D1%82%D1%8C",
+                    ),
+                ],
+                [True, False]
+            )
+        )
+    )
+    @unpack
+    def test_normalize_url(self, original_url, expected_url, as_str):
+        original_url = get_url(original_url, as_str)
+        received_url = normalize_url(original_url)
+        assert isinstance(received_url, URL)
+        assert expected_url == str(received_url)


### PR DESCRIPTION
Fixes #231. I just saw that there already is a merge request that fixes this (#219). You can of course decide which version you want to accept.

While writing the tests, I noticed that the project is using the library ddt. I think `pytest.mark.parametrize` works much more elegantly. With ddt, my test setup got a bit awkward.