### PR TITLE
fix: aiohttp 3.9 _writer can't await

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -156,7 +156,10 @@ class RequestMatch(object):
             method=method,
             headers=CIMultiDictProxy(CIMultiDict(**request_headers)),
         )
-        kwargs['writer'] = Mock()
+        if AIOHTTP_VERSION >= parse_version("3.9.0b1"):
+            kwargs['writer'] = AsyncMock()()
+        else:
+            kwargs['writer'] = Mock()
         kwargs['continue100'] = None
         kwargs['timer'] = TimerNoop()
         kwargs['traces'] = []

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -156,10 +156,7 @@ class RequestMatch(object):
             method=method,
             headers=CIMultiDictProxy(CIMultiDict(**request_headers)),
         )
-        if AIOHTTP_VERSION >= parse_version("3.9.0b1"):
-            kwargs['writer'] = AsyncMock()()
-        else:
-            kwargs['writer'] = Mock()
+        kwargs['writer'] = None
         kwargs['continue100'] = None
         kwargs['timer'] = TimerNoop()
         kwargs['traces'] = []


### PR DESCRIPTION
Fixed the problem mentioned in bug #247 and https://github.com/aio-libs/aiohttp/issues/7675#issuecomment-1804524374