### PR TITLE
Feature: Use base_url and headers from ClientSession

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -497,6 +497,13 @@ class aioresponses(object):
             raise RuntimeError('Session is closed')
 
         url_origin = url
+        # construct URL with ClientSession._base_url
+        if getattr(orig_self, "_base_url", None):
+            url_origin = f"{orig_self._base_url}{url}"
+            url = f"{orig_self._base_url}{url}"
+        # retrieve ClientSession headers
+        if orig_self.headers:
+            kwargs["headers"] = orig_self.headers
         url = normalize_url(merge_params(url, kwargs.get('params')))
         url_str = str(url)
         for prefix in self._passthrough:

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -496,14 +496,14 @@ class aioresponses(object):
         if orig_self.closed:
             raise RuntimeError('Session is closed')
 
-        url_origin = url
-        # construct URL with ClientSession._base_url
-        if getattr(orig_self, "_base_url", None):
-            url_origin = f"{orig_self._base_url}{url}"
-            url = f"{orig_self._base_url}{url}"
-        # retrieve ClientSession headers
+        # Join url with ClientSession._base_url
+        url = orig_self._build_url(url)
+        url_origin = str(url)
+
+        # Combine ClientSession headers with passed headers
         if orig_self.headers:
-            kwargs["headers"] = orig_self.headers
+            kwargs["headers"] = orig_self._prepare_headers(kwargs.get("headers"))
+
         url = normalize_url(merge_params(url, kwargs.get('params')))
         url_str = str(url)
         for prefix in self._passthrough:

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -212,6 +212,9 @@ class RequestMatch(object):
             reason=result.reason)
         return resp
 
+    def __repr__(self) -> str:
+        return f"RequestMatch('{self.url_or_pattern}')"
+
 
 RequestCall = namedtuple('RequestCall', ['args', 'kwargs'])
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,5 @@ pytest-html==2.1.1
 ddt==1.4.1
 typing
 asynctest==0.13.0
-yarl==1.8.2
+yarl==1.9.4
+setuptools==69.5.1


### PR DESCRIPTION
This PR includes the essential changes from https://github.com/pnuckowski/aioresponses/pull/239 but without reformatting other code, i.e. this supersedes #239.

Fixes #230 