### PR TITLE
Fix compat with aiohttp 3.11.0+

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -155,6 +155,7 @@ class RequestMatch(object):
             url=url,
             method=method,
             headers=CIMultiDictProxy(CIMultiDict(**request_headers)),
+            real_url=url
         )
         kwargs['writer'] = None
         kwargs['continue100'] = None


### PR DESCRIPTION
This is still backwards compatible with older versions (tested with 3.10.11 and 3.9.5) as well.