### PR TITLE
Use non-deprecated iscoroutinefunction API

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -189,7 +189,7 @@ class RequestMatch(object):
         self, url: URL, **kwargs: Any
     ) -> 'Union[ClientResponse, Exception]':
         if callable(self.callback):
-            if asyncio.iscoroutinefunction(self.callback):
+            if inspect.iscoroutinefunction(self.callback):
                 result = await self.callback(url, **kwargs)
             else:
                 result = self.callback(url, **kwargs)
@@ -250,7 +250,7 @@ class aioresponses(object):
                 args += (ctx,)
             return args, kwargs
 
-        if asyncio.iscoroutinefunction(f):
+        if inspect.iscoroutinefunction(f):
             @wraps(f)
             async def wrapped(*args, **kwargs):
                 with self as ctx:


### PR DESCRIPTION
At least in Python-3.14 this raises deprecation warnings otherwise. 