### PR TITLE
update python versions

### DIFF
--- a/aioresponses/__init__.py
+++ b/aioresponses/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .core import CallbackResult, aioresponses
 
 __version__ = '0.7.9'

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,19 +1,14 @@
-# -*- coding: utf-8 -*-
-import asyncio  # noqa: F401
-import sys
-from typing import Dict, Optional, Union  # noqa
+import asyncio
+from re import Pattern
+from typing import Dict, Optional, Union
 from urllib.parse import parse_qsl, urlencode
 
-from aiohttp import __version__ as aiohttp_version, StreamReader
+from aiohttp import RequestInfo, StreamReader
+from aiohttp import __version__ as aiohttp_version
 from aiohttp.client_proto import ResponseHandler
 from multidict import MultiDict
 from packaging.version import Version
 from yarl import URL
-
-if sys.version_info < (3, 7):
-    from re import _pattern_type as Pattern
-else:
-    from re import Pattern
 
 AIOHTTP_VERSION = Version(aiohttp_version)
 
@@ -42,20 +37,6 @@ def normalize_url(url: 'Union[URL, str]') -> 'URL':
     url = URL(url)
     return url.with_query(urlencode(sorted(parse_qsl(url.query_string))))
 
-
-try:
-    from aiohttp import RequestInfo
-except ImportError:
-    class RequestInfo(object):
-        __slots__ = ('url', 'method', 'headers', 'real_url')
-
-        def __init__(
-            self, url: URL, method: str, headers: Dict, real_url: str
-        ):
-            self.url = url
-            self.method = method
-            self.headers = headers
-            self.real_url = real_url
 
 __all__ = [
     'URL',

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -22,7 +22,7 @@ def stream_reader_factory(  # noqa
 
 def merge_params(
     url: 'Union[URL, str]',
-    params: Optional[Dict] = None
+    params: dict | None = None
 ) -> 'URL':
     url = URL(url)
     if params:

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -1,6 +1,6 @@
 import asyncio
 from re import Pattern
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 from urllib.parse import parse_qsl, urlencode
 
 from aiohttp import RequestInfo, StreamReader

--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -4,13 +4,10 @@ from typing import Optional, Union
 from urllib.parse import parse_qsl, urlencode
 
 from aiohttp import RequestInfo, StreamReader
-from aiohttp import __version__ as aiohttp_version
 from aiohttp.client_proto import ResponseHandler
 from multidict import MultiDict
-from packaging.version import Version
 from yarl import URL
 
-AIOHTTP_VERSION = Version(aiohttp_version)
 
 
 def stream_reader_factory(  # noqa
@@ -42,7 +39,6 @@ __all__ = [
     'URL',
     'Pattern',
     'RequestInfo',
-    'AIOHTTP_VERSION',
     'merge_params',
     'stream_reader_factory',
     'normalize_url',

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -27,7 +27,6 @@ from aiohttp import (
 )
 from aiohttp.helpers import TimerNoop
 from multidict import CIMultiDict, CIMultiDictProxy
-from packaging.version import Version
 
 from .compat import (
     URL,
@@ -35,7 +34,7 @@ from .compat import (
     stream_reader_factory,
     merge_params,
     normalize_url,
-    RequestInfo, AIOHTTP_VERSION,
+    RequestInfo,
 )
 
 _FuncT = TypeVar("_FuncT", bound=Callable[..., Any])
@@ -503,15 +502,12 @@ class aioresponses:
         if orig_self.closed:
             raise RuntimeError('Session is closed')
 
-        if AIOHTTP_VERSION >= Version('3.8.0'):
-            # Join url with ClientSession._base_url
-            url = orig_self._build_url(url)
-            url_origin = str(url)
-            # Combine ClientSession headers with passed headers
-            if orig_self.headers:
-                kwargs["headers"] = orig_self._prepare_headers(kwargs.get("headers"))
-        else:
-            url_origin = url
+        # Join url with ClientSession._base_url
+        url = orig_self._build_url(url)
+        url_origin = str(url)
+        # Combine ClientSession headers with passed headers
+        if orig_self.headers:
+            kwargs["headers"] = orig_self._prepare_headers(kwargs.get("headers"))
 
         url = normalize_url(merge_params(url, kwargs.get('params')))
         url_str = str(url)

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -7,7 +7,6 @@ from functools import wraps
 from typing import (
     Any,
     cast,
-    Dict,
     List,
     Optional,
     Tuple,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,12 @@
+-r requirements.txt
 pip
 wheel
 flake8==5.0.4
-tox==3.19.0
-coverage==5.2.1
-Sphinx==1.5.6
-pytest==7.1.3
-pytest-cov==2.10.1
-pytest-html==2.1.1
+tox==4.46.3
+coverage==7.13.4
+Sphinx==7.1.2
+pytest==8.4.0
+pytest-cov==6.0.0
+pytest-html==4.0.0
 ddt==1.4.1
-typing
-asynctest==0.13.0
-yarl==1.9.4
+yarl==1.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 packaging>=22.0
-aiohttp>=3.3.0,<4.0.0
+aiohttp>=3.8.0,<4.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,11 +15,11 @@ classifier =
   License :: OSI Approved :: MIT License
   Natural Language :: English
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.7
-  Programming Language :: Python :: 3.8
-  Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
+  Programming Language :: Python :: 3.12
+  Programming Language :: Python :: 3.13
+  Programming Language :: Python :: 3.14
 
 [files]
 packages =

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,28 +1,15 @@
-# -*- coding: utf-8 -*-
 import asyncio
-import sys
-
-try:
-    # as from Py3.8 unittest supports coroutines as test functions
-    from unittest import IsolatedAsyncioTestCase, skipIf
+from unittest import IsolatedAsyncioTestCase
 
 
-    def fail_on(**kw):  # noqa
-        def outer(fn):
-            def inner(*args, **kwargs):
-                return fn(*args, **kwargs)
+def fail_on(**kw):  # noqa
+    def outer(fn):
+        def inner(*args, **kwargs):
+            return fn(*args, **kwargs)
 
-            return inner
+        return inner
 
-        return outer
-
-
-except ImportError:
-    # fallback to asynctest
-    from asynctest import fail_on, skipIf
-    from asynctest.case import TestCase as IsolatedAsyncioTestCase
-
-IS_GTE_PY38 = sys.version_info >= (3, 8)
+    return outer
 
 
 class AsyncTestCase(IsolatedAsyncioTestCase):
@@ -39,20 +26,9 @@ class AsyncTestCase(IsolatedAsyncioTestCase):
     async def teardown(self):
         pass
 
-    if IS_GTE_PY38:
-        # from Python3.8
-        async def asyncSetUp(self):
-            self.loop = asyncio.get_event_loop()
-            await self.setup()
+    async def asyncSetUp(self):
+        self.loop = asyncio.get_event_loop()
+        await self.setup()
 
-        async def asyncTearDown(self):
-            await self.teardown()
-    else:
-        # asynctest
-        use_default_loop = False
-
-        async def setUp(self) -> None:
-            await self.setup()
-
-        async def tearDown(self) -> None:
-            await self.teardown()
+    async def asyncTearDown(self):
+        await self.teardown()

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import asyncio
 import re
 from asyncio import CancelledError, TimeoutError
@@ -10,8 +9,7 @@ from aiohttp import hdrs
 from aiohttp import http
 from aiohttp.client import ClientSession
 from aiohttp.client_reqrep import ClientResponse
-from ddt import ddt, data, unpack
-from packaging.version import Version
+from ddt import data, ddt, unpack
 
 try:
     from aiohttp.errors import (
@@ -26,12 +24,10 @@ except ImportError:
     )
     from aiohttp.http_exceptions import HttpProcessingError
 
-from aioresponses.compat import AIOHTTP_VERSION, URL
 from aioresponses import CallbackResult, aioresponses
-from .base import fail_on, skipIf, AsyncTestCase
+from aioresponses.compat import URL
 
-
-MINIMUM_AIOHTTP_VERSION = Version('3.4.0')
+from .base import AsyncTestCase, fail_on
 
 @ddt
 class AIOResponsesTestCase(AsyncTestCase):
@@ -86,7 +82,6 @@ class AIOResponsesTestCase(AsyncTestCase):
         ("http://example.com/", "/api?foo=bar#fragment")
     )
     @aioresponses()
-    @skipIf(condition=AIOHTTP_VERSION < Version('3.8.0'), reason='aiohttp must be >= 3.8.0')
     async def test_base_url(self, base_url, relative_url, m):
         m.get(self.url, status=200)
         self.session = ClientSession(base_url=base_url)
@@ -94,7 +89,6 @@ class AIOResponsesTestCase(AsyncTestCase):
         self.assertEqual(response.status, 200)
 
     @aioresponses()
-    @skipIf(condition=AIOHTTP_VERSION < Version('3.8.0'), reason='aiohttp must be >= 3.8.0')
     async def test_session_headers(self, m):
         m.get(self.url)
         self.session = ClientSession(headers={"Authorization": "Bearer foobar"})
@@ -147,9 +141,6 @@ class AIOResponsesTestCase(AsyncTestCase):
         self.assertEqual(cm.exception.message, http.RESPONSES[400][0])
 
     @aioresponses()
-    @skipIf(condition=AIOHTTP_VERSION < MINIMUM_AIOHTTP_VERSION,
-            reason='aiohttp<3.4.0 does not support raise_for_status '
-                   'arguments for requests')
     async def test_request_raise_for_status(self, m):
         m.get(self.url, status=400)
         with self.assertRaises(ClientResponseError) as cm:
@@ -710,9 +701,6 @@ class AIOResponsesRaiseForStatusSessionTestCase(AsyncTestCase):
         self.assertEqual(cm.exception.message, http.RESPONSES[400][0])
 
     @aioresponses()
-    @skipIf(condition=AIOHTTP_VERSION < MINIMUM_AIOHTTP_VERSION,
-            reason='aiohttp<3.4.0 does not support raise_for_status '
-                   'arguments for requests')
     async def test_do_not_raise_for_status(self, m):
         m.get(self.url, status=400)
         response = await self.session.get(self.url,
@@ -721,9 +709,6 @@ class AIOResponsesRaiseForStatusSessionTestCase(AsyncTestCase):
         self.assertEqual(response.status, 400)
 
     @aioresponses()
-    @skipIf(condition=AIOHTTP_VERSION < Version('3.9.0'),
-            reason='aiohttp<3.9.0 does not support callable raise_for_status '
-                   'arguments for requests')
     async def test_callable_raise_for_status(self, m):
         async def raise_for_status(response: ClientResponse):
             if response.status >= 400:

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -2,7 +2,8 @@ import asyncio
 import re
 from asyncio import CancelledError, TimeoutError
 from random import uniform
-from typing import Coroutine, Generator, Union
+from typing import Union
+from collections.abc import Coroutine, Generator
 from unittest.mock import patch
 
 from aiohttp import hdrs
@@ -41,7 +42,7 @@ class AIOResponsesTestCase(AsyncTestCase):
         if close_result is not None:
             await close_result
 
-    def run_async(self, coroutine: Union[Coroutine, Generator]):
+    def run_async(self, coroutine: Coroutine | Generator):
         return self.loop.run_until_complete(coroutine)
 
     async def request(self, url: str):
@@ -400,8 +401,7 @@ class AIOResponsesTestCase(AsyncTestCase):
     async def test_request_with_non_deepcopyable_parameter(self):
         def non_deep_copyable():
             """A generator does not allow deepcopy."""
-            for line in ["header1,header2", "v1,v2", "v10,v20"]:
-                yield line
+            yield from ["header1,header2", "v1,v2", "v10,v20"]
 
         generator_value = non_deep_copyable()
 
@@ -663,12 +663,12 @@ class AIOResponsesTestCase(AsyncTestCase):
         with aioresponses() as mocked:
             for i in range(20):
                 mocked.get(
-                    'http://example.org/id-{}'.format(i),
+                    f'http://example.org/id-{i}',
                     callback=random_sleep_cb
                 )
 
             tasks = [
-                self.session.get('http://example.org/id-{}'.format(i)) for
+                self.session.get(f'http://example.org/id-{i}') for
                 i in range(20)
             ]
             await asyncio.gather(*tasks)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import Union
 from unittest import TestCase
 
@@ -8,7 +7,7 @@ from yarl import URL
 from aioresponses.compat import merge_params
 
 
-def get_url(url: str, as_str: bool) -> Union[URL, str]:
+def get_url(url: str, as_str: bool) -> URL | str:
     return url if as_str else URL(url)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,11 @@
 envlist =
     flake8,
     coverage,
-    py37-aiohttp{33,34,35,36,37,38}
-    py38-aiohttp{33,34,35,36,37,38}
-    py39-aiohttp{37,38}
-    py310-aiohttp{37,38}
-    py31-aiohttp38
+    py310-aiohttp{38,39,310,311}
+    py311-aiohttp{38,39,310,311,312}
+    py312-aiohttp{39,310,311,312,313}
+    py313-aiohttp{310,311,312,313}
+    py314-aiohttp{313}
 skipsdist = True
 
 [testenv:flake8]
@@ -21,12 +21,12 @@ setenv =
 passenv = PYTEST_ADDOPTS
 
 deps =
-    aiohttp33: aiohttp>=3.3,<3.4
-    aiohttp34: aiohttp>=3.4,<3.5
-    aiohttp35: aiohttp>=3.5,<3.6
-    aiohttp36: aiohttp>=3.6,<3.7
-    aiohttp37: aiohttp>=3.7,<3.8
     aiohttp38: aiohttp>=3.8,<3.9
+    aiohttp39: aiohttp>=3.9,<3.10
+    aiohttp310: aiohttp>=3.10,<3.11
+    aiohttp311: aiohttp>=3.11,<3.12
+    aiohttp312: aiohttp>=3.12,<3.13
+    aiohttp313: aiohttp>=3.13,<3.14
     -r{toxinidir}/requirements-dev.txt
 
 commands = python -m pytest {posargs}


### PR DESCRIPTION
Remove support for python 3.7, 3.8 and 3.9 that are EOL.
remove support for aiohttp 3.7 or less that requires python 3.9 or less
Update dev dependencies to work with python3.14
Update tox to run on more modern python versions
remove workarrounds for old versions