### PR TITLE
fix: normalize HTTP method case when recording requests

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -551,7 +551,7 @@ class aioresponses(object):
                     orig_self, method, url_origin, *args, **kwargs
                 ))
 
-        key = (method, url)
+        key = (method.upper(), url)
         self.requests.setdefault(key, [])
         request_call = self._build_request_call(method, *args, **kwargs)
         self.requests[key].append(request_call)

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -709,6 +709,13 @@ class AIOResponsesTestCase(AsyncTestCase):
         m.assert_any_call(http_bin_url)
 
     @aioresponses()
+    async def test_assert_any_call_lowercase_method(self, m: aioresponses):
+        m.get(self.url)
+        await self.session.request('get', self.url)
+        m.assert_any_call(self.url)
+        m.assert_called_with(self.url)
+
+    @aioresponses()
     async def test_assert_any_call_not_called(self, m: aioresponses):
         http_bin_url = "http://httpbin.org"
         m.get(self.url)


### PR DESCRIPTION
Requests made with a lowercase method (e.g. `session.request('get', url)`) were stored in `self.requests` with the raw method name, so `assert_any_call`/`assert_called_with` (which uppercase the method) raised a spurious `call not found`. This normalizes the method to uppercase when recording. Closes #238.