### PR TITLE
fix: support aiohttp 3.14 required stream_writer argument

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -183,6 +183,12 @@ class RequestMatch(object):
             real_url=url
         )
         kwargs['writer'] = None
+        # aiohttp 3.14 added a required keyword-only ``stream_writer`` argument
+        # to ``ClientResponse.__init__``. It is only consulted for its
+        # ``output_size`` attribute, so a lightweight mock is sufficient. The
+        # signature check keeps this a no-op on aiohttp < 3.14.
+        if 'stream_writer' in inspect.signature(response_class).parameters:
+            kwargs['stream_writer'] = Mock(output_size=0)
         kwargs['continue100'] = None
         kwargs['timer'] = TimerNoop()
         kwargs['traces'] = []


### PR DESCRIPTION
aiohttp 3.14.0 added a required keyword-only ``stream_writer`` argument to ``ClientResponse.__init__``. aioresponses constructs the response class without it, so every mocked response raised:

    TypeError: ClientResponse.__init__() missing 1 required
    keyword-only argument: 'stream_writer'

aiohttp only reads ``stream_writer.output_size``, so a ``Mock(output_size=0)`` is sufficient. A signature check on the response class keeps this a no-op on aiohttp < 3.14 and respects custom response classes.