### PR TITLE
ci: test against aiohttp 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-minor-version: [10, 11, 12, 13, 14]
-        aiohttp-version: [aiohttp38, aiohttp39, aiohttp310, aiohttp311, aiohttp312, aiohttp313]
+        aiohttp-version: [aiohttp38, aiohttp39, aiohttp310, aiohttp311, aiohttp312, aiohttp313, aiohttp314]
         exclude:
           # aiohttp 3.8 supports Python up to 3.10
           - aiohttp-version: aiohttp38
@@ -48,6 +48,9 @@ jobs:
             python-minor-version: 14
           # aiohttp 3.13 supports Python 3.10-3.14 (no excludes)
           - aiohttp-version: aiohttp313
+            python-minor-version: 10
+          # aiohttp 3.14 supports Python 3.11-3.14
+          - aiohttp-version: aiohttp314
             python-minor-version: 10
     runs-on: ${{ matrix.os }}
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 envlist =
     flake8,
     py310-aiohttp{38,39,310,311,312},
-    py311-aiohttp{39,310,311,312,313},
-    py312-aiohttp{39,310,311,312,313},
-    py313-aiohttp{310,311,312,313},
-    py314-aiohttp313,
+    py311-aiohttp{39,310,311,312,313,314},
+    py312-aiohttp{39,310,311,312,313,314},
+    py313-aiohttp{310,311,312,313,314},
+    py314-aiohttp{313,314},
     coverage
 no_package = true
 skip_missing_interpreters = true
@@ -27,6 +27,7 @@ deps =
     aiohttp311: aiohttp~=3.11.0
     aiohttp312: aiohttp~=3.12.0
     aiohttp313: aiohttp~=3.13.0
+    aiohttp314: aiohttp~=3.14.0
 commands =
     python -m pytest -q {posargs}
 


### PR DESCRIPTION
Add aiohttp 3.14 to the CI matrix and tox envlist so the new stream_writer support is exercised. aiohttp 3.14 supports Python 3.11-3.14, so it is excluded for Python 3.10.