### PR TITLE
fix: support aiohttp 3.14 pause_reading

### DIFF
--- a/aioresponses/compat.py
+++ b/aioresponses/compat.py
@@ -2,6 +2,7 @@
 import asyncio  # noqa: F401
 from re import Pattern
 from typing import Dict, Optional, Union  # noqa
+from unittest.mock import Mock
 from urllib.parse import parse_qsl, urlencode
 
 from aiohttp import __version__ as aiohttp_version, StreamReader
@@ -17,6 +18,10 @@ def stream_reader_factory(  # noqa
     loop: 'Optional[asyncio.AbstractEventLoop]' = None
 ) -> StreamReader:
     protocol = ResponseHandler(loop=loop)
+    # Satisfies BaseProtocol's flow control hooks that
+    # fire when a large payload exceeds the StreamReader limit.
+    protocol._parser = Mock()
+    protocol._parser.feed_data.return_value = ([], False, b'')
     return StreamReader(protocol, limit=2 ** 16, loop=loop)
 
 

--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -182,6 +182,8 @@ class RequestMatch(object):
             headers=CIMultiDictProxy(self._prepare_request_headers(request_headers)),
             real_url=url
         )
+        if 'stream_writer' in inspect.signature(response_class).parameters:
+            kwargs['stream_writer'] = Mock(output_size=0)
         kwargs['writer'] = None
         kwargs['continue100'] = None
         kwargs['timer'] = TimerNoop()

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -4,9 +4,10 @@ import re
 from asyncio import CancelledError, TimeoutError
 from random import uniform
 from typing import Coroutine, Generator, Union
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from aiohttp import hdrs
+from aiohttp.base_protocol import BaseProtocol
 from aiohttp import http
 from aiohttp.client import ClientSession
 from aiohttp.client_reqrep import ClientResponse
@@ -311,6 +312,14 @@ class AIOResponsesTestCase(AsyncTestCase):
         resp = await self.session.get(self.url)
         content = await resp.content.read()
         self.assertEqual(content, b'Test')
+
+    @aioresponses()
+    async def test_streaming_large_body(self, m):
+        body = b'x' * (1024 * 1024)
+        m.get(self.url, body=body)
+        resp = await self.session.get(self.url)
+        content = await resp.content.read()
+        self.assertEqual(content, body)
 
     @aioresponses()
     async def test_streaming_up_to(self, m):

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
     flake8,
-    py310-aiohttp{38,39,310,311,312},
-    py311-aiohttp{39,310,311,312,313},
-    py312-aiohttp{39,310,311,312,313},
-    py313-aiohttp{310,311,312,313},
-    py314-aiohttp313,
+    py310-aiohttp{38,39,310,311,312,314},
+    py311-aiohttp{39,310,311,312,313,314},
+    py312-aiohttp{39,310,311,312,313,314},
+    py313-aiohttp{310,311,312,313,314},
+    py314-aiohttp{313,314},
     coverage
 no_package = true
 skip_missing_interpreters = true
@@ -27,6 +27,7 @@ deps =
     aiohttp311: aiohttp~=3.11.0
     aiohttp312: aiohttp~=3.12.0
     aiohttp313: aiohttp~=3.13.0
+    aiohttp314: aiohttp~=3.14.0
 commands =
     python -m pytest -q {posargs}
 


### PR DESCRIPTION
aiohttp 3.14 reworked flow control: BaseProtocol.pause_reading() now asserts self._parser is not None and delegates to self._parser.pause_reading()
https://github.com/aio-libs/aiohttp/pull/12355

aioresponses constructs a bare ResponseHandler with no parser, so reading a body larger than the StreamReader limit (2**16) raises AssertionError.
Fix: attach a mock parser to the protocol where feed_data returns an empty tuple so the resume path (data_received(b"")) works.

Separately, 3.14's ClientResponse takes a stream_writer kwarg — mocked in core.py (from https://github.com/pnuckowski/aioresponses/pull/288).