### PR TITLE
avoid key error on args_to_match

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -422,7 +422,10 @@ class aioresponses(object):
 
         if args_to_match is not None:
             raise_error = any(
-                arg not in actual.kwargs or actual.kwargs[arg] != expected.kwargs[arg] for arg in args_to_match)
+                arg not in actual.kwargs
+                or arg not in expected.kwargs
+                or actual.kwargs[arg] != expected.kwargs[arg]
+                for arg in args_to_match)
         else:
             raise_error = actual != expected
 

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -304,6 +304,13 @@ class AIOResponsesTestCase(AsyncTestCase):
                 data=body,
                 headers={'User-Agent': 'aioresponses'}
             )
+        # when a args_to_match is not on the assertion, it should raise assertion error
+        with self.assertRaises(AssertionError):
+            m.assert_called_once_with(
+                self.url,
+                method='POST',
+                args_to_match=['headers'],
+            )
 
     @aioresponses()
     async def test_streaming(self, m):


### PR DESCRIPTION
If args_to_match has a value that is on the actual args, but not on the expected args, it was raising a keyError. I changed to AssertionError, but could be a more explicit key error, or other exception.
same PR on aioresponses-ng: https://github.com/MountainGod2/aioresponses-ng/pull/18