### PR TITLE
Preserve HTTP method on 307/308 redirects (and non-POST 301/302)

### DIFF
--- a/aioresponses/core.py
+++ b/aioresponses/core.py
@@ -510,7 +510,17 @@ class aioresponses(object):
                     url = redirect_url
                 else:
                     url = url.join(redirect_url)
-                method = 'get'
+                # Mirror aiohttp's behaviour when rewriting the method on a
+                # redirect: 303 always becomes GET, 301/302 downgrade only a
+                # POST to GET (other methods are preserved), and 307/308 keep
+                # the original method. See aiohttp.ClientSession._request.
+                if response.status == 303 and method.upper() != hdrs.METH_HEAD:
+                    method = 'get'
+                elif (
+                    response.status in (301, 302)
+                    and method.upper() == hdrs.METH_POST
+                ):
+                    method = 'get'
                 continue
             else:
                 break

--- a/tests/test_aioresponses.py
+++ b/tests/test_aioresponses.py
@@ -806,6 +806,7 @@ class AIOResponsesRaiseForStatusSessionTestCase(AsyncTestCase):
         self.assertEqual(str(cm.exception), "callable raise_for_status")
 
 
+@ddt
 class AIOResponseRedirectTest(AsyncTestCase):
 
     async def setup(self):
@@ -835,18 +836,62 @@ class AIOResponseRedirectTest(AsyncTestCase):
 
     @aioresponses()
     async def test_post_redirect_followed(self, rsps):
+        # A 307 redirect must preserve the original request method, so a POST
+        # stays a POST when the redirect is followed (matching aiohttp).
         rsps.post(
             self.url,
             status=307,
             headers={"Location": "https://httpbin.org"},
         )
-        rsps.get("https://httpbin.org")
+        rsps.post("https://httpbin.org")
         response = await self.session.post(
             self.url, allow_redirects=True
         )
         self.assertEqual(response.status, 200)
         self.assertEqual(str(response.url), "https://httpbin.org")
-        self.assertEqual(response.method, "get")
+        self.assertEqual(response.method, "post")
+        self.assertEqual(len(response.history), 1)
+        self.assertEqual(str(response.history[0].url), self.url)
+
+    @unpack
+    @data(
+        # status, request method, expected method after redirect
+        (307, "post", "post"),
+        (307, "put", "put"),
+        (307, "delete", "delete"),
+        (308, "post", "post"),
+        (308, "put", "put"),
+        (308, "delete", "delete"),
+        (303, "post", "get"),
+        (303, "put", "get"),
+        (301, "post", "get"),
+        (302, "post", "get"),
+        (301, "put", "put"),
+        (302, "put", "put"),
+        (301, "delete", "delete"),
+        (302, "delete", "delete"),
+    )
+    @aioresponses()
+    async def test_redirect_preserves_method(
+        self, status, request_method, expected_method, rsps
+    ):
+        target = "https://httpbin.org"
+        rsps.add(
+            self.url,
+            method=request_method,
+            status=status,
+            headers={"Location": target},
+        )
+        # Register the target only for the method we expect the redirect to
+        # be re-issued with; if the method is rewritten incorrectly the
+        # request will fail to match and raise ClientConnectionError.
+        rsps.add(target, method=expected_method)
+        response = await getattr(self.session, request_method)(
+            self.url, allow_redirects=True
+        )
+        self.assertEqual(response.status, 200)
+        self.assertEqual(str(response.url), target)
+        self.assertEqual(response.method, expected_method)
         self.assertEqual(len(response.history), 1)
         self.assertEqual(str(response.history[0].url), self.url)
 


### PR DESCRIPTION
## Summary

Following a redirect always re-issued the request as `GET`, regardless of the redirect status code. Per the HTTP spec and aiohttp's own behaviour, that is only correct for some statuses:

- **307 / 308** must **preserve** the original method (and body).
- **301 / 302** downgrade a `POST` to `GET`, but **preserve** other methods (`PUT`, `DELETE`, ...).
- **303** always becomes `GET`.

Because of the blanket `method = 'get'`, mocking e.g. a `307` redirect of a `POST` wrongly re-issued it as a `GET`, so the redirect target registered for `POST` was never matched. This diverges from real `aiohttp`, which mocks are meant to emulate.

This fixes #283. The blanket rewrite was introduced in #159; the reasoning there ("all redirects should be GET") does not match the spec or aiohttp.

## Fix

In `aioresponses/core.py`, the redirect-following loop's unconditional `method = 'get'` is replaced with status-conditional logic that mirrors `aiohttp.ClientSession._request`:

- `303` (and non-`HEAD`) -> `GET`
- `301` / `302` + `POST` -> `GET`
- everything else (307/308, and non-`POST` 301/302) -> method preserved

## Tests

- Updated `test_post_redirect_followed`: a `307` `POST` now correctly stays a `POST`.
- Added `test_redirect_preserves_method`, a parametrized (`ddt`) regression test covering `POST`/`PUT`/`DELETE` across `301`, `302`, `303`, `307`, `308`, asserting the resulting method after the redirect is followed.

All redirect tests pass with the fix and fail without it. `flake8 aioresponses` is clean.

Disclosure: prepared with AI assistance; reviewed and verified locally.
